### PR TITLE
#341: support for readonly/writeonly properties to be skipped if the …

### DIFF
--- a/modules/xfmg/json/XMOM/xfmg/xfctrl/datamodel/json/parameter/JSONWritingOptions.xml
+++ b/modules/xfmg/json/XMOM/xfmg/xfctrl/datamodel/json/parameter/JSONWritingOptions.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2023 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,15 @@
   <Data Label="Use Labels" VariableName="useLabels">
     <Meta>
       <Type>boolean</Type>
+    </Meta>
+  </Data>
+  <Data Label="OAS Message Type" VariableName="oASMessageType">
+    <Meta>
+      <Type>String</Type>
+      <Documentation>Valid Values: Request, Response
+When set to Request, the Json will not contain any membervars that are marked as readOnly in their OAS datamodel Meta data.
+When set to Response, the Json will not contain any membervars that are marked as writeOnly in their OAS datamodel Meta data.
+If not set or set to a different value no membervars will be skipped.</Documentation>
     </Meta>
   </Data>
 </DataType>

--- a/modules/xfmg/json/application.xml
+++ b/modules/xfmg/json/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2023 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="Json" comment="" factoryVersion="" versionName="1.1.3" xmlVersion="1.1">
+<Application applicationName="Json" comment="" factoryVersion="" versionName="1.2.0" xmlVersion="1.1">
   <ApplicationInfo>
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>


### PR DESCRIPTION
…writeoption says response/request accordingly. properties must be marked as readonly/writeonly in the datatypes xml file as provided by the OAS datamodel type (not yet committed to github)