### PR TITLE
Fix: create typechoice input variable in correct revision

### DIFF
--- a/blackedition/blackedition_lib.sh
+++ b/blackedition/blackedition_lib.sh
@@ -30,7 +30,7 @@ ALL_DATAMODELTYPES=("mib","tr069","xsd");
 #ACHTUNG: Version auch bei addRequirement zu default workspace berücksichtigen
 ALL_APPLICATIONS="Base Processing"; #Default-Applications, die immer installiert sein sollten
 APPMGMTVERSION=1.0.10
-GUIHTTPVERSION=1.1.370
+GUIHTTPVERSION=1.1.371
 SNMPSTATVERSION=1.0.3
 PROCESSINGVERSION=1.0.17
 ALL_REPOSITORYACCESSES=("svn");

--- a/modules/xmcp/gitIntegration/application.xml
+++ b/modules/xmcp/gitIntegration/application.xml
@@ -20,7 +20,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.1.370</VersionName>
+        <VersionName>1.1.371</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xmcp/guihttp/application.xml
+++ b/modules/xmcp/guihttp/application.xml
@@ -17,7 +17,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <!--                                               ################# Version auch in blackedition_lib.sh updaten ########### -->
-<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.1.370" xmlVersion="1.1">
+<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.1.371" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">GuiHTTPFilter</Description>
     <Description Lang="EN">GuiHTTPFilter</Description>

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/session/modify/operations/copy/StepCopier.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/session/modify/operations/copy/StepCopier.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2023 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -250,20 +250,24 @@ public class StepCopier {
 
 
   /*package*/ static AVariable copyVariable(AVariable sourceVar, WF parentWFObject, CopyData cpyData) {
-    Map<String, String> idMap = cpyData.getVariableIdMap();
-    String idOfCopy = null;
     String idOfOriginal = sourceVar.getId();
     if (idOfOriginal == null) {
       return copyVariableInternal(null, sourceVar, parentWFObject, cpyData);
     }
 
-    idOfCopy = idMap.get(idOfOriginal);
+    String idOfCopy = getOrAddIdOfVarCopy(idOfOriginal, parentWFObject, cpyData);
+    return copyVariableInternal(idOfCopy, sourceVar, parentWFObject, cpyData);
+  }
+
+
+  /* package*/ static String getOrAddIdOfVarCopy(String idOfOriginal, WF parentWFObject, CopyData cpyData) {
+    Map<String, String> idMap = cpyData.getVariableIdMap();
+    String idOfCopy = idMap.get(idOfOriginal);
     if (idOfCopy == null) {
-      idOfCopy = "" + parentWFObject.getNextXmlId();
+      idOfCopy = String.valueOf(parentWFObject.getNextXmlId());
       idMap.put(idOfOriginal, idOfCopy);
     }
-
-    return copyVariableInternal(idOfCopy, sourceVar, parentWFObject, cpyData);
+    return idOfCopy;
   }
 
 


### PR DESCRIPTION
The problem was that the typechoice input variable was created with the runtimecontext defining that variable type. If you have a typechoice on base.Text and created a Datatype extending base.Text (childDT), then a typechoice on base.Text will have two lanes: base.Text and childDT. Despite being defined in the 'Base' Application, the choice input has the revision of the current workspace. That is why the childDT is visible.
During the copy to clipboard operation, the new choice input variable was created in the context of the 'Base' Application, instead of the current workspace. As a result, all derived Datatypes not visible from the 'Base' Application were lost.