### PR TITLE
#137: cleanup of obsolete storablestructureinfo subtypeentries

### DIFF
--- a/server/src/com/gip/xyna/xnwh/persistence/xmom/ODSRegistrationParameter.java
+++ b/server/src/com/gip/xyna/xnwh/persistence/xmom/ODSRegistrationParameter.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2023 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,10 +290,12 @@ public class ODSRegistrationParameter {
     if (ssi.getFqClassNameForDatatype().equals(type)) {
       return ssi;
     } else {
-      for (StorableStructureIdentifier subType : ssi.getSubEntries()) {
-        StorableStructureInformation result = findTypeInHierarchy(subType.getInfo(), type);
-        if (result != null) {
-          return result;
+      if (ssi.getSubEntries() != null) {
+        for (StorableStructureIdentifier subType : ssi.getSubEntries()) {
+          StorableStructureInformation result = findTypeInHierarchy(subType.getInfo(), type);
+          if (result != null) {
+            return result;
+          }
         }
       }
       return null;

--- a/server/src/com/gip/xyna/xnwh/persistence/xmom/PersistenceExpressionVisitors.java
+++ b/server/src/com/gip/xyna/xnwh/persistence/xmom/PersistenceExpressionVisitors.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2023 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -735,8 +735,10 @@ public class PersistenceExpressionVisitors {
     private List<String> collectSubTypesRecursivly(StorableStructureInformation type) {
       List<String> types = new ArrayList<>();
       types.add(type.getFqXmlName());
-      for (StorableStructureIdentifier subEntry : type.getSubEntries()) {
-        types.addAll(collectSubTypesRecursivly(subEntry.getInfo()));
+      if (type.getSubEntries() != null) {
+        for (StorableStructureIdentifier subEntry : type.getSubEntries()) {
+          types.addAll(collectSubTypesRecursivly(subEntry.getInfo()));
+        }
       }
       return types;
     }


### PR DESCRIPTION
there could remain obsolete entries in the xmomstorablestructurecache subentries when changing runtimecontextdependencies which lead to NPEs...