### PR TITLE
[GuiHttp] properly terminate Orphaned poll-request cleaner thread

### DIFF
--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/session/SessionBasedData.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/session/SessionBasedData.java
@@ -288,8 +288,6 @@ public class SessionBasedData {
             break;
           }
         }
-
-        terminateOrphanCleaner = false;
       }
     };
 


### PR DESCRIPTION
When a SessionBasedData object is created, a session termination handler is registered for the relevant session (XMOMGui 191). The session gets terminated during logout in LogoutAction 62.

The session termination handler calls SessionBasedData::clean, setting terminateOrphanCleaner to true. With this PR, terminateOrpahnCleaner is only initialized with false and only changes to true in the clean method. No other assignments.