### PR TITLE
629 obsolete storable structure cache entries

### DIFF
--- a/.github/workflows/build-on-pull-request.yml
+++ b/.github/workflows/build-on-pull-request.yml
@@ -27,7 +27,7 @@ jobs:
        env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
        run: |
-          gh pr diff ${{ github.event.pull_request.number }} --name-only | grep '^modules/' | cut -f 2-3 -d/ | sort | uniq | tee changed-modules.txt
+          gh pr diff ${{ github.event.pull_request.number }} --name-only | xargs -I {} dirname {} | grep '^modules/' | cut -f 2-3 -d/ | sort | uniq | tee changed-modules.txt
 
      - name: build basic factory
        run: |

--- a/modules/xact/build.xml
+++ b/modules/xact/build.xml
@@ -32,6 +32,7 @@
         <buildModule target="build"     dir="soap"        target.dir="${target.dir}/xact" />
         <buildModule target="build"     dir="snmp"        target.dir="${target.dir}/xact" />
         <buildModule target="build-all" dir="ssh"         target.dir="${target.dir}/xact" />
+        <buildModule target="build"     dir="velocity"    target.dir="${target.dir}/xact" />
     </target>
     
 </project>

--- a/modules/xact/build.xml
+++ b/modules/xact/build.xml
@@ -32,7 +32,7 @@
         <buildModule target="build"     dir="soap"        target.dir="${target.dir}/xact" />
         <buildModule target="build"     dir="snmp"        target.dir="${target.dir}/xact" />
         <buildModule target="build-all" dir="ssh"         target.dir="${target.dir}/xact" />
-        <buildModule target="build"     dir="velocity"    target.dir="${target.dir}/xact" />
+        <!--<buildModule target="build"     dir="velocity"    target.dir="${target.dir}/xact" /> -->
     </target>
     
 </project>

--- a/server/src/com/gip/xyna/xnwh/persistence/xmom/XMOMPersistenceOperationAlgorithms.java
+++ b/server/src/com/gip/xyna/xnwh/persistence/xmom/XMOMPersistenceOperationAlgorithms.java
@@ -1839,15 +1839,10 @@ public class XMOMPersistenceOperationAlgorithms implements XMOMPersistenceOperat
   
   public static class TypeCollectionVisitor implements StorableStructureVisitor {
 
-    private Map<String, Collection<StorableStructureInformation>> types = new HashMap<>();
+    private Set<String> types = new HashSet<>();
     
     public void enter(StorableColumnInformation columnLink, StorableStructureInformation current) {
-      Collection<StorableStructureInformation> subtypes = types.get(current.getFqXmlName());
-      if (subtypes == null) {
-        subtypes = new HashSet<>();
-        types.put(current.getFqXmlName(), subtypes);
-      }
-      subtypes.add(current);
+      types.add(current.getFqXmlName());
     }
 
     public void exit(StorableColumnInformation columnLink, StorableStructureInformation current) {
@@ -1857,7 +1852,7 @@ public class XMOMPersistenceOperationAlgorithms implements XMOMPersistenceOperat
       return XMOMStorableStructureCache.ALL_RECURSIONS_AND_FULL_HIERARCHY;
     }
     
-    public Map<String, Collection<StorableStructureInformation>> getTypes() {
+    public Set<String> getTypes() {
       return types;
     }
     


### PR DESCRIPTION
gbs.clear() was missing at the end of the unregistration. that could lead to problems later on, because at some point the lines
if (current.getFqClassNameForDatatype().equals(gb.getFqClassName())) { // remove types that are currently being removed
              affectedRootIter.remove();
              continue outer;
            }

will skip objects that should be handled.