### PR TITLE
Issue #425 delivering new -roleName as optional argument

### DIFF
--- a/server/clicommands/ListRoles.xml
+++ b/server/clicommands/ListRoles.xml
@@ -17,4 +17,5 @@
 -->
 <XynaCommandLineCommand>
   <CommandDefinition Name="listroles" Groups="User Management" Description="Lists all registered roles."/>
+  <Argument Name="roleName" Description="Lists only the rights for a given role name" Optional="true"/>
 </XynaCommandLineCommand>

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ListrolesImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ListrolesImpl.java
@@ -40,50 +40,66 @@ public class ListrolesImpl extends XynaCommandImplementation<Listroles> {
     UserManagement um = XynaFactory.getInstance().getFactoryManagement().getXynaOperatorControl().getUserManagement();
     Collection<Role> roles = um.getRoles();
     StringBuilder rolesOut = new StringBuilder();
-    for (Role role : roles) {
-      if (um.isPredefined(PredefinedCategories.ROLE, role.getId())) {
-        rolesOut.append(role.getName());
-        rolesOut.append("* - ");
-      } else {
-        rolesOut.append(role.getName());
-        rolesOut.append(" - ");
-      }
-
-      rolesOut.append(role.getDomain());
-
-      if (role.getAlias() != null && !role.getAlias().equals("")) {
-        rolesOut.append(" - alias: ");
-        rolesOut.append(role.getAlias());
-      }
-
-      if (role.getDescription() != null && !role.getDescription().equals("")) {
-        rolesOut.append(" - ");
-        rolesOut.append(role.getDescription());
-      }
-
-      rolesOut.append("\n");
-      Set<String> rights = new TreeSet<String>(role.getRightsAsList());
-      for (String right : rights) {
-        rolesOut.append(INDENT_FOR_LISTS);
-        rolesOut.append(right);
-        rolesOut.append("\n");
-      }
-      if (role.getScopedRights() != null) {
-        Set<String> scopedRights = new TreeSet<String>(role.getScopedRights());
-        for (String scopedRight : scopedRights) {
-          rolesOut.append(INDENT_FOR_LISTS);
-          rolesOut.append(scopedRight);
-          rolesOut.append("\n");
-        }
-      }
+    String specificRole = payload.getRoleName();
+    boolean hasSpecificRole = specificRole != null && !specificRole.isEmpty(); 
+    if( hasSpecificRole ){
+	// clear roles to create empty output for non-existent role and therefore trigger message afterwards
+	roles.clear();
+	
+	// check if requested role really exists
+	if(um.getRole(specificRole) != null){
+	    roles.add( um.getRole(specificRole) );
+	}
     }
-    rolesOut.append("*: Xyna-Role - only restricted access allowed\n");
+    for (Role role : roles) {
+	if (um.isPredefined(PredefinedCategories.ROLE, role.getId())) {
+	    rolesOut.append(role.getName());
+	    rolesOut.append("* - ");
+	} else {
+	    rolesOut.append(role.getName());
+	    rolesOut.append(" - ");
+	}
+	
+	rolesOut.append(role.getDomain());
+	
+	if (role.getAlias() != null && !role.getAlias().equals("")) {
+	    rolesOut.append(" - alias: ");
+	    rolesOut.append(role.getAlias());
+	}
+
+	if (role.getDescription() != null && !role.getDescription().equals("")) {
+	    rolesOut.append(" - ");
+	    rolesOut.append(role.getDescription());
+	}
+
+	rolesOut.append("\n");
+	Set<String> rights = new TreeSet<String>(role.getRightsAsList());
+	for (String right : rights) {
+	    rolesOut.append(INDENT_FOR_LISTS);
+	    rolesOut.append(right);
+	    rolesOut.append("\n");
+	}
+	if (role.getScopedRights() != null) {
+	    Set<String> scopedRights = new TreeSet<String>(role.getScopedRights());
+	    for (String scopedRight : scopedRights) {
+		rolesOut.append(INDENT_FOR_LISTS);
+		rolesOut.append(scopedRight);
+		rolesOut.append("\n");
+	    }
+	}
+    }
     String output = rolesOut.toString();
-    if (output != null && output.length() != 0) {
-      writeToCommandLine(statusOutputStream, output);
-    } else {
-      writeToCommandLine(statusOutputStream, "No roles defined on server\n");
+    if (output != null && output.length() != 0){
+	rolesOut.append("*: Xyna-Role - only restricted access allowed\n");
+	output = rolesOut.toString();
+	writeToCommandLine(statusOutputStream, output);
+    }
+    else if(hasSpecificRole){
+	writeToCommandLine(statusOutputStream, "Role name " + specificRole + " does not exist\n");
+    }
+    else {
+	writeToCommandLine(statusOutputStream, "No roles defined on server\n");
     }
   }
-
+    
 }


### PR DESCRIPTION
When working in the region of that code I realized that the check for the empty output String did not help:
```diff
-    rolesOut.append("*: Xyna-Role - only restricted access allowed\n");
     String output = rolesOut.toString();
-    if (output != null && output.length() != 0) {
-      writeToCommandLine(statusOutputStream, output);
-    } else {
-      writeToCommandLine(statusOutputStream, "No roles defined on server\n");
+    if (output != null && output.length() != 0){
+       rolesOut.append("*: Xyna-Role - only restricted access allowed\n");
+       output = rolesOut.toString();
+       writeToCommandLine(statusOutputStream, output);
+    }
+    else if(hasSpecificRole){
+       writeToCommandLine(statusOutputStream, "Role name " + specificRole + " does not exist\n");
+    }
+    else {
+       writeToCommandLine(statusOutputStream, "No roles defined on server\n");
     }
   }
```
Previously in any case the `rolesOut.append("*: Xyna-Role - only restricted access allowed\n");` added something to the output String such that it could never reach the if statement empty or null. 
Therefore I moved the append. Hope this does not destroy something other unintentionally. 