### PR TITLE
upgrade log4j version to 2.17.2, should solve #49

### DIFF
--- a/installation/build/pom.xml
+++ b/installation/build/pom.xml
@@ -412,22 +412,22 @@
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-1.2-api</artifactId>
-                <version>2.17.1</version>
+                <version>2.17.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-api</artifactId>
-                <version>2.17.1</version>
+                <version>2.17.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-core</artifactId>
-                <version>2.17.1</version>
+                <version>2.17.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.logging.log4j</groupId>
                 <artifactId>log4j-slf4j-impl</artifactId>
-                <version>2.17.1</version>
+                <version>2.17.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.sshd</groupId>


### PR DESCRIPTION
Having a look into the changelog from log4j version 2.17.1 to 2.17.2 shows no breaking changes:
[RELEASE-NOTES.md.txt](https://github.com/Xyna-Factory/xyna-factory/files/14721647/RELEASE-NOTES.md.txt)

It only states that 

> Due to a break in compatibility in the SLF4J binding, Log4j now ships with two versions of the SLF4J to Log4j adapters.
log4j-slf4j-impl should be used with SLF4J 1.7.x and earlier and log4j-slf4j18-impl should be used with SLF4J 1.8.x and
later.

But we already use log4j-slf4j-impl as lib and should be save therefore. 
