### PR TITLE
Make members of SSLKeystoreParameters mappable again

### DIFF
--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/ldap/SSLKeystoreParameter.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/ldap/SSLKeystoreParameter.java
@@ -417,7 +417,7 @@ public class SSLKeystoreParameter extends SSLParameter {
       return foundField;
     }
     try {
-      foundField = SSLParameter.class.getDeclaredField(target_fieldname);
+      foundField = SSLKeystoreParameter.class.getDeclaredField(target_fieldname);
     } catch (NoSuchFieldException e) {
     }
     if (foundField == null) {


### PR DESCRIPTION
Class change to SSLKeystoreParameter in order to fix issue #33.

### Test
Tested with a locally generated `xynafactory.jar`: 
#### Before fix
A simple mapping using *SSLKeystoreParameter* can be deployed as described in #33, but yields to the following error:
```java
com.gip.xyna.xprc.xprcods.orderarchive.XynaExceptionInformationThrowable: com.gip.xyna.xdev.exceptions.XDEV_PARAMETER_NAME_NOT_FOUND: Parameter with name  -  does not exist
	at da.devtest.XynaFactory33$Step1.executeInternally(XynaFactory33.java:194)
	at    ... (21 more)
	at ----- Caused by com.gip.xyna.xprc.xfractwfe.InvalidObjectPathException Parameter with name path does not exist. (depth: 1)
	at com.gip.xyna.xfmg.xopctrl.usermanagement.ldap.SSLParameter.getField(SSLParameter.java:168)
	at com.gip.xyna.xfmg.xopctrl.usermanagement.ldap.SSLKeystoreParameter.getField(SSLKeystoreParameter.java:424)
	at da.devtest.XynaFactory33$Step1.executeInternally(XynaFactory33.java:179)
	at com.gip.xyna.xprc.xfractwfe.base.FractalProcessStep.execute(FractalProcessStep.java:280)
	at com.gip.xyna.xprc.xfractwfe.base.FractalProcessStep.executeChildren(FractalProcessStep.java:159)
	at da.devtest.XynaFactory33$Step0.executeInternally(XynaFactory33.java:128)
	at com.gip.xyna.xprc.xfractwfe.base.FractalProcessStep.execute(FractalProcessStep.java:280)
	at com.gip.xyna.xprc.xfractwfe.base.XynaProcess.executeInternally(XynaProcess.java:194)
	at com.gip.xyna.xprc.xfractwfe.base.XynaProcess.execute(XynaProcess.java:616)
	at
```

#### After fix
Running the simple mapping with the workflow launcher works again:
![grafik](https://github.com/Xyna-Factory/xyna-factory/assets/41345639/4414d03b-d4ab-4978-b639-b3e28ef1142b)
