### PR TITLE
removed additional dependencies leading to errors in #199

### DIFF
--- a/modules/xact/velocity/sharedlib/TemplateStorables/pom.xml
+++ b/modules/xact/velocity/sharedlib/TemplateStorables/pom.xml
@@ -37,16 +37,6 @@
     <dependencies>
         <dependency>
             <groupId>com.gip.xyna</groupId>
-            <artifactId>RemoteGenericODSAccess</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.gip.xyna</groupId>
-            <artifactId>XynaContentStorables</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.gip.xyna</groupId>
             <artifactId>xynafactory</artifactId>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Testing the generated app without the above dependecies did work on my test machine and generated correct template code. 

Due to the discussion in #199 I would suggest to remove them completely. Especially when there is no information available about where the source code of the dependencies resides. Therefore I also suggest @corneliuslippert-gip as a reviewer.

I do not know the whereabouts of the source code either. 