### PR TITLE
New Flag in order to export internal Roles as well

### DIFF
--- a/server/clicommands/ExportRoles.xml
+++ b/server/clicommands/ExportRoles.xml
@@ -18,4 +18,5 @@
 <XynaCommandLineCommand>
   <CommandDefinition Name="exportroles" Groups="User Management" Description="Generates a shell script that will import all roles, domains and rights registered on this Xyna Factory."/>
   <Argument Name="scriptName" Description="The name of file to be created"/>
+  <BoolOption Name="i" LongName="includePredefinedRoles" Description="The generated shell script will include the predefined Xyna Factory roles." Optional="true"/>
 </XynaCommandLineCommand>

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportdomainsImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportdomainsImpl.java
@@ -59,7 +59,7 @@ public class ExportdomainsImpl extends XynaCommandImplementation<Exportdomains> 
 
       BufferedOutputStream scriptStream = new BufferedOutputStream(new FileOutputStream(scriptFile));
 
-      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream, false)) {
+      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream)) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportdomainsImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportdomainsImpl.java
@@ -59,7 +59,7 @@ public class ExportdomainsImpl extends XynaCommandImplementation<Exportdomains> 
 
       BufferedOutputStream scriptStream = new BufferedOutputStream(new FileOutputStream(scriptFile));
 
-      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream)) {
+      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream, false)) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportrolesImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportrolesImpl.java
@@ -82,7 +82,7 @@ public class ExportrolesImpl extends XynaCommandImplementation<Exportroles> {
         scriptFile.delete();
         return;
       }
-      if (!generateDomainImports(factory, scriptStream, payload.getIncludePredefinedRoles())) {
+      if (!generateDomainImports(factory, scriptStream)) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();
@@ -154,11 +154,11 @@ public class ExportrolesImpl extends XynaCommandImplementation<Exportroles> {
   }
 
 
-  static boolean generateDomainImports(XynaFactoryPortal factory, OutputStream scriptStream, boolean withPredefinedRoles)
+  static boolean generateDomainImports(XynaFactoryPortal factory, OutputStream scriptStream)
       throws PersistenceLayerException {
     Collection<Domain> domains = factory.getFactoryManagementPortal().getDomains();
     for (Domain domain : domains) {
-      if (!factory.getFactoryManagementPortal().isPredefined(PredefinedCategories.DOMAIN, domain.getName()) || withPredefinedRoles) {
+      if (!factory.getFactoryManagementPortal().isPredefined(PredefinedCategories.DOMAIN, domain.getName())) {
         try {
           scriptStream.write(("./xynafactory.sh createdomain " + domain.getName() + " " + domain.getDomainType()
               + domain.getMaxRetries() + " " + domain.getConnectionTimeout() + "\n")

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportrolesImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportrolesImpl.java
@@ -82,14 +82,14 @@ public class ExportrolesImpl extends XynaCommandImplementation<Exportroles> {
         scriptFile.delete();
         return;
       }
-      if (!generateDomainImports(factory, scriptStream)) {
+      if (!generateDomainImports(factory, scriptStream, payload.getIncludePredefinedRoles())) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();
         scriptFile.delete();
         return;
       }
-      if (!generateRoleImports(factory, scriptStream)) {
+      if (!generateRoleImports(factory, scriptStream, payload.getIncludePredefinedRoles())) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();
@@ -109,13 +109,13 @@ public class ExportrolesImpl extends XynaCommandImplementation<Exportroles> {
   }
 
 
-  static boolean generateRoleImports(XynaFactoryPortal factory, OutputStream scriptStream)
+  static boolean generateRoleImports(XynaFactoryPortal factory, OutputStream scriptStream, boolean withPredefinedRoles)
       throws PersistenceLayerException {
 
     Collection<Role> roles = factory.getFactoryManagementPortal().getRoles();
     for (Role role : roles) {
       if (!factory.getFactoryManagementPortal().isPredefined(PredefinedCategories.ROLE,
-                                                             role.getName() + role.getDomain())) {
+                                                             role.getName() + role.getDomain()) || withPredefinedRoles) {
         try {
           scriptStream.write(("./" + Constants.SERVER_SHELLNAME + " createrole " + role.getName() + " "
               + role.getDomain() + "\n").getBytes(Constants.DEFAULT_ENCODING));
@@ -154,11 +154,11 @@ public class ExportrolesImpl extends XynaCommandImplementation<Exportroles> {
   }
 
 
-  static boolean generateDomainImports(XynaFactoryPortal factory, OutputStream scriptStream)
+  static boolean generateDomainImports(XynaFactoryPortal factory, OutputStream scriptStream, boolean withPredefinedRoles)
       throws PersistenceLayerException {
     Collection<Domain> domains = factory.getFactoryManagementPortal().getDomains();
     for (Domain domain : domains) {
-      if (!factory.getFactoryManagementPortal().isPredefined(PredefinedCategories.DOMAIN, domain.getName())) {
+      if (!factory.getFactoryManagementPortal().isPredefined(PredefinedCategories.DOMAIN, domain.getName()) || withPredefinedRoles) {
         try {
           scriptStream.write(("./xynafactory.sh createdomain " + domain.getName() + " " + domain.getDomainType()
               + domain.getMaxRetries() + " " + domain.getConnectionTimeout() + "\n")

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportusersImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportusersImpl.java
@@ -68,14 +68,14 @@ public class ExportusersImpl extends XynaCommandImplementation<Exportusers> {
         scriptFile.delete();
         return;
       }
-      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream)) {
+      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream, false)) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();
         scriptFile.delete();
         return;
       }
-      if (!ExportrolesImpl.generateRoleImports(factory, scriptStream)) {
+      if (!ExportrolesImpl.generateRoleImports(factory, scriptStream, false)) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();

--- a/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportusersImpl.java
+++ b/server/src/com/gip/xyna/xmcp/xfcli/impl/ExportusersImpl.java
@@ -68,7 +68,7 @@ public class ExportusersImpl extends XynaCommandImplementation<Exportusers> {
         scriptFile.delete();
         return;
       }
-      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream, false)) {
+      if (!ExportrolesImpl.generateDomainImports(factory, scriptStream)) {
         writeToCommandLine(statusOutputStream, "The script '" + payload.getScriptName() + "' could not be created\n");
         logger.warn("Could not create import script, error while writing to file");
         scriptStream.close();


### PR DESCRIPTION
This is a proposal to solve #1350. 

A brief test looks like this:
```shell
xyna@f0f0163f02a0:/opt/xyna/xyna_001/server$ ./xynafactory.sh exportroles -scriptName w_o_SpecialRoles.sh
The script 'w_o_SpecialRoles.sh' was succesfully created
xyna@f0f0163f02a0:/opt/xyna/xyna_001/server$ ./xynafactory.sh exportroles -i -scriptName with_SpecialRoles.sh
The script 'with_SpecialRoles.sh' was succesfully created
```

Comparing the above resulting export files yields a shell script with *ADMIN* and *MODELLER*:
```diff
xyna@f0f0163f02a0:/opt/xyna/xyna_001/server$ diff -u w_o_SpecialRoles.sh with_SpecialRoles.sh 
--- w_o_SpecialRoles.sh	2025-02-18 20:39:37.891253988 +0000
+++ with_SpecialRoles.sh	2025-02-18 20:40:32.677474926 +0000
@@ -10,3 +10,93 @@
 ./xynafactory.sh createright xmcp.xfm.processmonitor.ordermonitor
 ./xynafactory.sh createright xmcp.xfm.processmonitor.resourcemonitor
 ./xynafactory.sh createright xmcp.xfm.testFactory
+./xynafactory.sh createdomain XYNA Local0 -1
+./xynafactory.sh createrole MODELLER XYNA
+./xynafactory.sh grantright MODELLER DEPLOYMENT_MDM
+./xynafactory.sh grantright MODELLER ORDERARCHIVE_VIEW
+./xynafactory.sh grantright MODELLER ORDERARCHIVE_DETAILS
+./xynafactory.sh grantright MODELLER PROCESS_MANUAL_INTERACTION
+./xynafactory.sh grantright MODELLER VIEW_MANUAL_INTERACTION
+./xynafactory.sh grantright MODELLER EDIT_MDM
+./xynafactory.sh grantright MODELLER READ_MDM
+./xynafactory.sh grantright MODELLER START_ORDER
+./xynafactory.sh grantright MODELLER SESSION_CREATION
+./xynafactory.sh grantright MODELLER USER_LOGIN
+./xynafactory.sh grantright MODELLER USER_MANAGEMENT
+./xynafactory.sh grantright MODELLER USER_MANAGEMENT_EDIT_OWN
+./xynafactory.sh grantright MODELLER FREQUENCY_CONTROL_MANAGEMENT
+./xynafactory.sh grantright MODELLER FREQUENCY_CONTROL_VIEW
+./xynafactory.sh grantright MODELLER WORKINGSET_MANAGEMENT
+./xynafactory.sh grantright MODELLER APPLICATION_MANAGEMENT
+./xynafactory.sh grantright MODELLER APPLICATION_ADMINISTRATION
+./xynafactory.sh grantright MODELLER xmcp.xfm.factoryManager
+./xynafactory.sh grantright MODELLER xmcp.xfm.processModeller
+./xynafactory.sh grantright MODELLER xmcp.xfm.processMonitor
+./xynafactory.sh grantright MODELLER xmcp.xfm.testFactory
+./xynafactory.sh grantright MODELLER xmcp.xfm.acm
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.dataModels:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.orderInputSources:*:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.cronLikeOrders:*:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.orderTypes:*:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.deploymentMarker:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.capacities:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.ApplicationDefinitionManagement:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.administrativeVetos:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.WorkspaceManagement:*:*
+./xynafactory.sh grantright MODELLER xnwh.persistence.Storables:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.ApplicationManagement:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.deploymentItems:*:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.timeControlledOrders:*:*:*:*
+./xynafactory.sh grantright MODELLER xfmg.xfctrl.XynaProperties:*:*
+./xynafactory.sh createrole ADMIN XYNA
+./xynafactory.sh grantright ADMIN TRIGGER_FILTER_MANAGEMENT
+./xynafactory.sh grantright ADMIN MONITORING_LEVEL_MANAGEMENT
+./xynafactory.sh grantright ADMIN PERSISTENCE_MANAGEMENT
+./xynafactory.sh grantright ADMIN START_ORDER
+./xynafactory.sh grantright ADMIN PROCESS_MANUAL_INTERACTION
+./xynafactory.sh grantright ADMIN EDIT_MDM
+./xynafactory.sh grantright ADMIN DEPLOYMENT_MDM
+./xynafactory.sh grantright ADMIN READ_MDM
+./xynafactory.sh grantright ADMIN USER_MANAGEMENT
+./xynafactory.sh grantright ADMIN ORDERARCHIVE_VIEW
+./xynafactory.sh grantright ADMIN ORDERARCHIVE_DETAILS
+./xynafactory.sh grantright ADMIN DISPATCHER_MANAGEMENT
+./xynafactory.sh grantright ADMIN VIEW_MANUAL_INTERACTION
+./xynafactory.sh grantright ADMIN SESSION_CREATION
+./xynafactory.sh grantright ADMIN USER_LOGIN
+./xynafactory.sh grantright ADMIN FREQUENCY_CONTROL_MANAGEMENT
+./xynafactory.sh grantright ADMIN FREQUENCY_CONTROL_VIEW
+./xynafactory.sh grantright ADMIN USER_MANAGEMENT_EDIT_OWN
+./xynafactory.sh grantright ADMIN KILL_STUCK_PROCESS
+./xynafactory.sh grantright ADMIN WORKINGSET_MANAGEMENT
+./xynafactory.sh grantright ADMIN APPLICATION_MANAGEMENT
+./xynafactory.sh grantright ADMIN APPLICATION_ADMINISTRATION
+./xynafactory.sh grantright ADMIN TOPOLOGY_MODELLER
+./xynafactory.sh grantright ADMIN xmcp.xfm.factoryManager
+./xynafactory.sh grantright ADMIN xmcp.xfm.processModeller
+./xynafactory.sh grantright ADMIN xmcp.xfm.processMonitor
+./xynafactory.sh grantright ADMIN xmcp.xfm.processmonitor.ordermonitor
+./xynafactory.sh grantright ADMIN xmcp.xfm.processmonitor.mimonitor
+./xynafactory.sh grantright ADMIN xmcp.xfm.processmonitor.livereporting
+./xynafactory.sh grantright ADMIN xmcp.xfm.processmonitor.resourcemonitor
+./xynafactory.sh grantright ADMIN xmcp.xfm.processmodeller.debug.showxml
+./xynafactory.sh grantright ADMIN xmcp.xfm.processmodeller.stealLock
+./xynafactory.sh grantright ADMIN xmcp.xfm.testFactory
+./xynafactory.sh grantright ADMIN xmcp.xfm.acm
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.dataModels:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.orderInputSources:*:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.cronLikeOrders:*:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.orderTypes:*:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.deploymentMarker:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.FilterManagement:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.capacities:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.ApplicationDefinitionManagement:*:*:*
+./xynafactory.sh grantright ADMIN base.fileaccess:*:/tmp/*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.TriggerManagement:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.WorkspaceManagement:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.administrativeVetos:*:*
+./xynafactory.sh grantright ADMIN xnwh.persistence.Storables:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.ApplicationManagement:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.deploymentItems:*:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.timeControlledOrders:*:*:*:*
+./xynafactory.sh grantright ADMIN xfmg.xfctrl.XynaProperties:*:*
```

Currently I am not sure if we should expand this flag to `exportusers` and `exportdomain` as well, as they use the same method `generateDomainImports`?