### PR TITLE
Backport: recognize host key verification response as valid JunOS prompt

### DIFF
--- a/modules/xact/devicetypes/JunOSDevice/mdmimpl/JunOSDeviceImpl/lib/JunOSDevice.conf
+++ b/modules/xact/devicetypes/JunOSDevice/mdmimpl/JunOSDeviceImpl/lib/JunOSDevice.conf
@@ -89,6 +89,7 @@ PROMPTS
 .*;(.*[\\r\\n]\\s*)?login:\\s?
 .*;(.*[\\r\\n]\\s*)?(?:\\w+@[\\d.]+'s\\s?)?[pP]assword:\\s?
 .*;.*Are you sure you want to restore factory settings?\\(Y/N\\):\\s?
+.*;.*Are you sure you want to continue connecting \\([yY]e?s?/[Nn]o?\\)\\?\\s?
 .*;.*Power on reboot requested by user\\s?
 .*;(.*[\\r\\n]\\s*)?S/Key challenge:\\s?
 


### PR DESCRIPTION
(cherry picked from commit 9fe0aeebd0b8fdc12dc6c99fd70cf500974a27f5)