### PR TITLE
backport fix cve-2025-48734 (#1669)

### DIFF
--- a/datamodeltypes/MIB/build.xml
+++ b/datamodeltypes/MIB/build.xml
@@ -25,7 +25,7 @@
     <property name="project.name.local" value="MIB" />
 
     <!--Next release version for the archive file-->
-    <property name="release.number" value="1.0.0"/>
+    <property name="release.number" value="1.0.1"/>
 
     <property name="target.dir" value="${basedir}/deploy" />
 

--- a/datamodeltypes/MIB/pom.xml
+++ b/datamodeltypes/MIB/pom.xml
@@ -28,7 +28,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>MIB</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/installation/build/pom.xml
+++ b/installation/build/pom.xml
@@ -257,7 +257,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
* update commons-beanutils to 1.11.0
* bump version of datamodeltypes/MIB to 1.0.1