### PR TITLE
prepare to use Xyna queue name instead of external queue

### DIFF
--- a/modules/xact/queue/activemq/application.xml
+++ b/modules/xact/queue/activemq/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/application.xml
+++ b/modules/xact/queue/activemq/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="ActiveMQ" comment="" factoryVersion="" versionName="1.0.7" xmlVersion="1.1">
+<Application applicationName="ActiveMQ" comment="" factoryVersion="" versionName="1.0.8" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">ActiveMQ</Description>
     <Description Lang="EN">ActiveMQ</Description>

--- a/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/pom.xml
+++ b/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2023 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/pom.xml
+++ b/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>ActiveMQForwardingFilter</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/src/com/gip/xyna/xact/filter/ActiveMQForwardingFilter.java
+++ b/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/src/com/gip/xyna/xact/filter/ActiveMQForwardingFilter.java
@@ -43,12 +43,20 @@ import javax.jms.TextMessage;
 
 import org.apache.log4j.Logger;
 import com.gip.xyna.utils.exceptions.XynaException;
+import com.gip.xyna.xfmg.xods.configuration.DocumentationLanguage;
+import com.gip.xyna.xfmg.xods.configuration.XynaPropertyUtils.XynaPropertyBoolean;
 import com.gip.xyna.xdev.xfractmod.xmdm.EventListener;
 
 public class ActiveMQForwardingFilter extends ConnectionFilter<ActiveMQTriggerConnection> {
 
+  private static final XynaPropertyBoolean useLegacyOrdertype 
+    = new XynaPropertyBoolean("xact.activemq.filter.forwarding.useLegacyOrdertype", true)
+      .setDefaultDocumentation(DocumentationLanguage.EN,
+                               "User ordertypename with external queue name and prefix xact.activemq.filter.forwarding.");
+
   private static Logger logger = CentralFactoryLogging.getLogger(ActiveMQForwardingFilter.class);
-  private static String ORDERTYPE_PREFIX = "xact.activemq.filter.forwarding.";
+  private static String LEGACY_ORDERTYPE_PREFIX = "xact.activemq.filter.forwarding.";
+  private static String ORDERTYPE_PREFIX = "xact.activemq.filter.forwarding.ProcessActiveMQMessage.queue=";
 
   /**
    * Analyzes TriggerConnection and creates XynaOrder if it accepts the connection.
@@ -65,7 +73,12 @@ public class ActiveMQForwardingFilter extends ConnectionFilter<ActiveMQTriggerCo
    *         Results in onError() being called by Xyna Processing.
    */
   public FilterResponse createXynaOrder(ActiveMQTriggerConnection tc) throws XynaException {
-    logger.info("Received Active MQ message on queue " + tc.getMessage());
+    if (logger.isDebugEnabled()) {
+      logger.debug("Received Active MQ message on queue " + tc.getXynaQueueMgmtQueueName() + ", " + tc.getExternalQueueName());
+    }
+    if (logger.isTraceEnabled()) {
+      logger.trace("Message: " + tc.getMessage());
+    }
 
     XynaOrder xynaOrder = null;
     try {
@@ -98,12 +111,19 @@ public class ActiveMQForwardingFilter extends ConnectionFilter<ActiveMQTriggerCo
       messageProperties.setProperties( getProperties(tc.getMessage()) );
       queueMessage.setMessageProperties(messageProperties);
       
+      String orderTypeToBeStarted = "";
+      if (useLegacyOrdertype.get()) {
+        String queueNameStr = tc.getExternalQueueName();
+        String adjustedQueueName = queueNameStr.substring(0, 1).toUpperCase() + queueNameStr.substring(1);
+        orderTypeToBeStarted = LEGACY_ORDERTYPE_PREFIX + adjustedQueueName;
+      } else {
+        String queueNameStr = tc.getXynaQueueMgmtQueueName();
+        orderTypeToBeStarted = ORDERTYPE_PREFIX + queueNameStr;
+      }
 
-      String queueNameStr = tc.getXynaQueueMgmtQueueName();
-      String adjustedQueueName = queueNameStr.substring(0, 1).toUpperCase() + queueNameStr.substring(1);
-      String orderTypeToBeStarted = ORDERTYPE_PREFIX + adjustedQueueName;
-
-      logger.info("Going to start Order Type " + orderTypeToBeStarted);
+      if (logger.isDebugEnabled()) {
+        logger.debug("Going to start Order Type " + orderTypeToBeStarted);
+      }
       DestinationKey destKey = new DestinationKey(orderTypeToBeStarted);
       xynaOrder = new XynaOrder(destKey, queueMessage);
       return FilterResponse.responsible(xynaOrder);

--- a/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/src/com/gip/xyna/xact/filter/ActiveMQForwardingFilter.java
+++ b/modules/xact/queue/activemq/filterimpl/ActiveMQForwardingFilter/src/com/gip/xyna/xact/filter/ActiveMQForwardingFilter.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/pom.xml
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/pom.xml
@@ -27,7 +27,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
     <artifactId>ActiveMQTrigger</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.3</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/pom.xml
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2023 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQStartParameter.java
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQStartParameter.java
@@ -34,6 +34,7 @@ public class ActiveMQStartParameter implements StartParameter {
   private String hostname;
   private int port;
   private String queueName;
+  private String xynaQueueMgmtQueueName;
   //milliseconds
   private int reconnectIntervalAfterError = 3000;
   private boolean autoReconnect = true;
@@ -65,6 +66,7 @@ public class ActiveMQStartParameter implements StartParameter {
     this.hostname = connData.getHostname();
     this.port = connData.getPort();
     this.queueName = queue.getExternalName();
+    this.xynaQueueMgmtQueueName = queue.getUniqueName();
   }
 
 
@@ -215,11 +217,15 @@ public class ActiveMQStartParameter implements StartParameter {
     return port;
   }
 
-
+  // return external queue name
   public String getQueueName() {
     return queueName;
   }
 
+  // return xyna unique queue name
+  public String getXynaQueueName() {
+    return xynaQueueMgmtQueueName;
+  }
 
   public int getReconnectIntervalAfterError() {
     return reconnectIntervalAfterError;

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQStartParameter.java
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQStartParameter.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTrigger.java
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTrigger.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTrigger.java
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTrigger.java
@@ -87,7 +87,7 @@ public class ActiveMQTrigger extends EventListener<ActiveMQTriggerConnection, Ac
       Destination destination = session.createQueue(startParameter.getQueueName());
       consumer = session.createConsumer(destination);
       if (logger.isInfoEnabled()) {
-        logger.info("connected to queue " + startParameter.getQueueName() + " on " + url);
+        logger.info("connected to queue " + startParameter.getXynaQueueName() + ", " + startParameter.getQueueName() + " on " + url);
       }
       running = true;
     } catch (JMSException e) {
@@ -104,7 +104,7 @@ public class ActiveMQTrigger extends EventListener<ActiveMQTriggerConnection, Ac
           if (logger.isTraceEnabled()) {
             traceMessage(msg);
           }
-          return new ActiveMQTriggerConnection(msg, startParameter.getQueueName());
+          return new ActiveMQTriggerConnection(msg, startParameter.getXynaQueueName(), startParameter.getQueueName());
         }
       } catch (JMSException e) {
         if (running) {
@@ -113,14 +113,15 @@ public class ActiveMQTrigger extends EventListener<ActiveMQTriggerConnection, Ac
       }
     }
     if (logger.isInfoEnabled()) {
-      logger.info("closing down connection to " + startParameter.getQueueName());
+      logger.info("closing down connection to " + startParameter.getXynaQueueName() + ", " + startParameter.getQueueName());
     }
     try {
       session.close();
       con.close();
     } catch (JMSException e) {
-      logger.error("error closing connection to " + startParameter.getHostname() + ":" + startParameter.getPort() + "/"
-                      + startParameter.getQueueName(), e);
+      logger.error("error closing connection to " + startParameter.getXynaQueueName() + ", "
+          + startParameter.getHostname() + ":" + startParameter.getPort() + "/"
+          + startParameter.getQueueName(), e);
     }
     return null;
   }

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTriggerConnection.java
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTriggerConnection.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2025 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTriggerConnection.java
+++ b/modules/xact/queue/activemq/triggerimpl/ActiveMQTrigger/src/com/gip/xyna/xact/trigger/ActiveMQTriggerConnection.java
@@ -34,10 +34,12 @@ public class ActiveMQTriggerConnection extends TriggerConnection {
 
   private transient Message msg;
   private transient String xynaQueueMgmtQueueName;
+  private transient String externalQueueName;
   
-  public ActiveMQTriggerConnection(Message msg, String xynaQueueMgmtQueueName) {
+  public ActiveMQTriggerConnection(Message msg, String xynaQueueMgmtQueueName, String externalQueueName) {
     this.msg = msg;
     this.xynaQueueMgmtQueueName = xynaQueueMgmtQueueName;
+    this.externalQueueName = externalQueueName;
   }
   
   public Message getMessage() {
@@ -46,6 +48,10 @@ public class ActiveMQTriggerConnection extends TriggerConnection {
   
   public String getXynaQueueMgmtQueueName() {
     return xynaQueueMgmtQueueName;
+  }
+  
+  public String getExternalQueueName() {
+    return externalQueueName;
   }
   
 }


### PR DESCRIPTION
add property for backwards compatibility
```java
  private static final XynaPropertyBoolean useLegacyOrdertype 
    = new XynaPropertyBoolean("xact.activemq.filter.forwarding.useLegacyOrdertype", true)
      .setDefaultDocumentation(DocumentationLanguage.EN,
                               "User ordertypename with external queue name and prefix xact.activemq.filter.forwarding.");
```
and to allow deprecation.
Switch to an ordertype name similar to the one use with HTTPForwarding
```java
  private static String ORDERTYPE_PREFIX = "xact.activemq.filter.forwarding.ProcessActiveMQMessage.queue=";
```

reduce Log-SPAM