### PR TITLE
Allow custom maven URLs

### DIFF
--- a/installation/build.sh
+++ b/installation/build.sh
@@ -26,7 +26,8 @@ print_help() {
   echo "Usage: $0 plugins"
   echo "Usage: $0 clusterproviders"
   echo "Usage: $0 conpooltypes"
-  echo "Usage: $0 install_libs"
+  # custom url useful for trusted/cached maven registry besides the official urls
+  echo "Usage: $0 install_libs [custom mvn base url]"
   #creates necessary libs for generating application xmls from workspace-xml (from gitintegration)
   # (invoked by buildApplication.xml generate-application-xml)
   echo "Usage: $0 install_gitintegration_libs (depends on build)"
@@ -63,9 +64,17 @@ install_libs() {
     exit 1
   fi
   HTTP_CODE_OK=200
+
+  # handle custom provided mvn url
+  MVN_BASE_URL=https://repo1.maven.org/maven2
+  if [ -n "${1}" ]; then
+    echo "Custom maven base URL provided: ${1}"
+    echo "Using custom URL for lib installation!"
+    MVN_BASE_URL=${1}
+  fi
   
   mkdir -p ${HOME}/.ant/lib
-  URL=https://repo1.maven.org/maven2/org/apache/maven/resolver/maven-resolver-ant-tasks/${MAVEN_RESOLVER_ANT_TASKS_VERSION}/maven-resolver-ant-tasks-${MAVEN_RESOLVER_ANT_TASKS_VERSION}-uber.jar
+  URL=${MVN_BASE_URL}/org/apache/maven/resolver/maven-resolver-ant-tasks/${MAVEN_RESOLVER_ANT_TASKS_VERSION}/maven-resolver-ant-tasks-${MAVEN_RESOLVER_ANT_TASKS_VERSION}-uber.jar
   TARGET_FILE=${HOME}/.ant/lib/maven-resolver-ant-tasks-${MAVEN_RESOLVER_ANT_TASKS_VERSION}-uber.jar
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" ${URL})
   if [ "$HTTP_CODE" != "$HTTP_CODE_OK" ]; then 
@@ -74,7 +83,7 @@ install_libs() {
   fi
   curl -s ${URL} -o "${TARGET_FILE}"
   
-  URL=https://repo1.maven.org/maven2/ant-contrib/ant-contrib/${ANT_CONTRIB_TASKS_VERSION}/ant-contrib-${ANT_CONTRIB_TASKS_VERSION}.jar
+  URL=${MVN_BASE_URL}/ant-contrib/ant-contrib/${ANT_CONTRIB_TASKS_VERSION}/ant-contrib-${ANT_CONTRIB_TASKS_VERSION}.jar
   TARGET_FILE="${HOME}/.ant/lib/ant-contrib-${ANT_CONTRIB_TASKS_VERSION}.jar"
   HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" ${URL})
   if [ "$HTTP_CODE" != "$HTTP_CODE_OK" ]; then 
@@ -650,7 +659,7 @@ case $1 in
     build_conpooltypes
     ;;
   "install_libs")
-    install_libs
+    install_libs ${2}
     ;;
   "cleanup_lib")
     cleanup_lib


### PR DESCRIPTION
In some projects there will be used cached/trusted registries for maven, which means that the official ones will be not available.

To be able to install the base libraries for Xyna in such cases the `install_libs` option now has an additional (optional) parameter to provide alternative base URLs for maven, i. e. 
```
./build.sh install_libs https://my_cached_mvn/repo
```