### PR TITLE
[GuiHttp] fix constant conversion

### DIFF
--- a/blackedition/blackedition_lib.sh
+++ b/blackedition/blackedition_lib.sh
@@ -31,7 +31,7 @@ GUIHTTP_APP="GuiHttp"
 #ACHTUNG: Version auch bei addRequirement zu default workspace berücksichtigen
 ALL_APPLICATIONS="Base Processing"; #Default-Applications, die immer installiert sein sollten
 APPMGMTVERSION=1.0.11
-GUIHTTPVERSION=1.4.5
+GUIHTTPVERSION=1.4.6
 SNMPSTATVERSION=1.0.4
 PROCESSINGVERSION=1.0.28
 ALL_REPOSITORYACCESSES=("svn");

--- a/modules/xdev/yang/application.xml
+++ b/modules/xdev/yang/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.4.5</VersionName>
+        <VersionName>1.4.6</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>YangBase</ApplicationName>

--- a/modules/xmcp/gitIntegration/application.xml
+++ b/modules/xmcp/gitIntegration/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.4.5</VersionName>
+        <VersionName>1.4.6</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xmcp/guihttp/application.xml
+++ b/modules/xmcp/guihttp/application.xml
@@ -17,7 +17,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <!--                                               ################# Version auch in blackedition_lib.sh updaten ########### -->
-<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.4.5" xmlVersion="1.1">
+<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.4.6" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">Interne Funktionalität zum Interagieren des Xyna Fractal Modellers mit dem Xyna Factory Server</Description>
     <Description Lang="EN">Internal functionality for interaction of the Xyna Fractal Modeller with the Xyna Factory Server</Description>

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/session/Dataflow.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/session/Dataflow.java
@@ -687,19 +687,15 @@ public class Dataflow {
     }
     return null;
   }
-  
-  private void createConstantConnection( AVariableIdentification varToConnect, AVariableIdentification existingLink, Map<AVariableIdentification, InputConnection> connections) {
+
+
+  private void createConstantConnection(AVariableIdentification varToConnect, AVariableIdentification existingLink, Map<AVariableIdentification, InputConnection> connections) {
     List<AVariableIdentification> inputVars = new ArrayList<AVariableIdentification>();
     inputVars.add(existingLink);
-    GeneralXynaObject constValue;
-    try {
-      constValue = existingLink.getIdentifiedVariable().getXoRepresentation();
-      String constant = Utils.xoToJson(constValue, existingLink.getIdentifiedVariable().getCreator().getRevision());
-      InputConnection inputConnection = new SimpleConnection(inputVars, LinkstateIn.CONSTANT, null, constant);
-      connections.put(varToConnect, inputConnection);
-    } catch (InvalidObjectPathException | XDEV_PARAMETER_NAME_NOT_FOUND e) {
-      throw new RuntimeException("Constant for EndDocument not found.");
-    }
+    AVariable constVar = existingLink.getIdentifiedVariable();
+    String constant = serializeConstant(constVar, constVar.getCreator().getRevision());
+    InputConnection inputConnection = new SimpleConnection(inputVars, LinkstateIn.CONSTANT, null, constant);
+    connections.put(varToConnect, inputConnection);
   }
   
   //
@@ -1942,12 +1938,8 @@ public class Dataflow {
         if (parameter.getIsUserConnected()[i]) {
           sc.setLinkState(LinkstateIn.USER);
         } else if (parameter.getIsConstantConnected()[i]) {
-          try {
-            GeneralXynaObject constValue = existingLink.getIdentifiedVariable().getXoRepresentation();
-            sc.setConstant(Utils.xoToJson(constValue, existingLink.getIdentifiedVariable().getCreator().getRevision()));
-          } catch (Exception e) {
-            sc.setConstant("");
-          }
+          AVariable existingVar = existingLink.getIdentifiedVariable();
+          sc.setConstant(serializeConstant(existingVar, existingVar.getCreator().getRevision()));
           sc.setLinkState(LinkstateIn.CONSTANT);
         } else {
           sc.inputVars.remove(existingLink);
@@ -3011,13 +3003,8 @@ public class Dataflow {
       SimpleConnection constantConnection = getSimpleConnection(toSatisfy, connections, branchId);
       constantConnection.setLinkState(LinkstateIn.CONSTANT);
       constantConnection.addInputVar(existingLink);
-      try {
-        GeneralXynaObject constValue = existingLink.getIdentifiedVariable().getXoRepresentation();
-        constantConnection.setConstant(Utils.xoToJson(constValue, existingLink.getIdentifiedVariable().getCreator().getRevision()));
-      } catch (Exception e) {
-        constantConnection.setConstant("");
-      }
-      
+      AVariable constValue = existingLink.getIdentifiedVariable();
+      constantConnection.setConstant(serializeConstant(constValue, constValue.getCreator().getRevision()));
       return constantConnection;
     } else if (branchId == null && toSatisfy.connectedness.isConstantConnected()) { //bei branchId!=null steht die constant-connectedness am assign-input (oberer fall)
       SimpleConnection constantConnection = getSimpleConnection(toSatisfy, connections, branchId);
@@ -3025,16 +3012,7 @@ public class Dataflow {
       constantConnection.setLinkState(LinkstateIn.CONSTANT);
       globalConstVar = Utils.getGlobalConstVar(toSatisfy.connectedness.getConnectedVariableId(), gbo.getWFStep());
       constantConnection.setInputVars(createConstConnInputVars(globalConstVar));
-      try {
-        if(globalConstVar.getCreator().getRevision() != StringXMLSource.REVISION) {
-          GeneralXynaObject constValue = globalConstVar.getXoRepresentation();
-          constantConnection.setConstant(Utils.xoToJson(constValue, globalConstVar.getCreator().getRevision()));
-        } else {
-          constantConnection.setConstant("");
-        }
-      } catch (Exception e) {
-        constantConnection.setConstant("");
-      }
+      constantConnection.setConstant(serializeConstant(globalConstVar, globalConstVar.getCreator().getRevision()));
       constantConnection.setInputVars(createConstConnInputVars(globalConstVar));
       return constantConnection;
     } else {
@@ -3856,18 +3834,35 @@ public class Dataflow {
   }
 
 
+  private String serializeConstant(AVariable value, Long revision) {
+    try {
+      return serializeConstant(value.getXoRepresentation(), revision);
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+
+  private String serializeConstant(GeneralXynaObject value, Long revision) {
+    try {
+      if (revision != StringXMLSource.REVISION) {
+        return Utils.xoToJson(value, revision);
+      } else {
+        return "";
+      }
+    } catch (Exception e) {
+      return "";
+    }
+  }
+
+
   public String setConstantValue(AVariableIdentification target, String branchId, GeneralXynaObject value) {
     SimpleConnection connectionToSetConstant = determineConnectionForConstant(target, branchId);
 
     // add global variable for new value - remove old if present
     AVariable constDataVar = AVariable.createFromXo(value, gbo.getWFStep().getCreator(), target.getIdentifiedVariable().isList());
     constDataVar.setId(gbo.getWFStep().getCreator().getNextXmlId().toString());
-    String constant = "";
-    try {
-      constant = Utils.xoToJson(value, constDataVar.getCreator().getRevision());
-    } catch(Exception e) {
-      //empty constant
-    }
+    String constant = serializeConstant(value, constDataVar.getCreator().getRevision());
     executeSetConstant(connectionToSetConstant, constDataVar, constant);
 
     return constDataVar.getId();

--- a/modules/xmcp/xypilot/application.xml
+++ b/modules/xmcp/xypilot/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.4.5</VersionName>
+        <VersionName>1.4.6</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>XyPilotMetricsDefaults</ApplicationName>


### PR DESCRIPTION
When opening audits containing constants in service outputs, an exception is logged, because the constant value is being converted using an invalid revision (-100). This change properly checks this for this context to prevent the exception.
* Dataflow - calls to Utils.toXoJson are performed using serializeConstant