### PR TITLE
[Backport] [Python Code Snippets] multiple outputs and lists (#2403)

### DIFF
--- a/server/src/com/gip/xyna/xprc/xfractwfe/XynaPythonSnippetManagement.java
+++ b/server/src/com/gip/xyna/xprc/xfractwfe/XynaPythonSnippetManagement.java
@@ -36,8 +36,6 @@ import com.gip.xyna.xprc.xfractwfe.python.PythonMdmGeneration;
 import com.gip.xyna.xprc.xfractwfe.python.PythonProjectGeneration;
 import com.gip.xyna.xprc.xfractwfe.python.jep.JepInterpreterFactory;
 
-import jep.python.PyObject;
-
 
 
 public class XynaPythonSnippetManagement extends Section {

--- a/server/src/com/gip/xyna/xprc/xfractwfe/generation/PythonOperation.java
+++ b/server/src/com/gip/xyna/xprc/xfractwfe/generation/PythonOperation.java
@@ -49,9 +49,9 @@ public class PythonOperation extends CodeOperation {
     type += var.isJavaBaseType ? var.getJavaTypeEnum().getJavaTypeName() : var.getOriginalPath() + "." + var.getOriginalName();
     type += var.isList ? ">" : "";
     String result = "(" + type + ")pyMgmt.convertToJava(context, \"" + type + "\", " + var.getVarName() + ")";
-    if(var.isList) {
-      String fqn = var.getOriginalPath() + "." + var.getOriginalName();
-      result = var.getVarName() + " == null ? null : new com.gip.xyna.xdev.xfractmod.xmdm.GeneralXynaObjectList("+ result + ", " + fqn + ".class)";
+    if (var.isList && !var.isJavaBaseType) {
+        String fqn = var.getOriginalPath() + "." + var.getOriginalName();
+        result = var.getVarName() + " == null ? null : new com.gip.xyna.xdev.xfractmod.xmdm.XynaObjectList(" + result + ", " + fqn + ".class)";
     }
     return result;
   }

--- a/server/src/com/gip/xyna/xprc/xfractwfe/python/PythonMdmGeneration.java
+++ b/server/src/com/gip/xyna/xprc/xfractwfe/python/PythonMdmGeneration.java
@@ -204,7 +204,7 @@ public class PythonMdmGeneration {
 
 
   private void fillDefaults(StringBuilder sb, boolean withImpl, boolean typeHints) {
-    fillImports(sb);
+    fillImports(sb, withImpl);
     fillBaseObject(sb, "XynaObject", "DATATYPE", null, withImpl, typeHints);
     fillBaseObject(sb, "XynaException", "EXCEPTION", "Exception", withImpl, typeHints);
     fillConvertToPythonObject(sb, withImpl, typeHints);
@@ -242,9 +242,13 @@ public class PythonMdmGeneration {
   }
 
 
-  private void fillImports(StringBuilder sb) {
+  private void fillImports(StringBuilder sb, boolean withImpl) {
     sb.append("import decimal\n");
-    sb.append("from com.gip.xyna import XynaFactory # type: ignore\n\n");
+    if (withImpl) {
+      sb.append("from com.gip.xyna import XynaFactory # type: ignore\n\n");
+    } else {
+      sb.append("\n");
+    }
   }
 
 


### PR DESCRIPTION
[Python Code Snippets]
* convert List Outputs to XynaObjectLists instead of GeneralXynaObjectLists
* only create XynaFactory import in mdm.py if implementation is generated
* support for primitive output lists