### PR TITLE
Feature jwt domain user authentication jsonwebtoken app

### DIFF
--- a/blackedition/blackedition_lib.sh
+++ b/blackedition/blackedition_lib.sh
@@ -31,7 +31,7 @@ GUIHTTP_APP="GuiHttp"
 #ACHTUNG: Version auch bei addRequirement zu default workspace berücksichtigen
 ALL_APPLICATIONS="Base Processing"; #Default-Applications, die immer installiert sein sollten
 APPMGMTVERSION=1.0.11
-GUIHTTPVERSION=1.5.3
+GUIHTTPVERSION=1.5.4
 SNMPSTATVERSION=1.0.4
 PROCESSINGVERSION=1.0.28
 ALL_REPOSITORYACCESSES=("svn");

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -1,0 +1,255 @@
+# Design Document: JWT Domain for User Authentication
+
+## Overview
+This document describes the current JWT authentication architecture in Xyna.
+
+The JWT domain supports two validation modes via `authValidationMode`:
+
+- `JWT`: full signature validation via JJWT + JWKS/OIDC discovery (default)
+- `HEADER`: no signature validation in Xyna; claims are read from the JWT payload
+
+The mode is selected through domain-specific data (`setdomaintypespecificdata`).
+
+- JWT domain setup for the order-backed flow also requires an `ordertype` and optionally a runtime context (`application` + `version` or `workspace`) to resolve the revision.
+- The JSONWebToken application exposes `authenticate` for this flow.
+- Role selection is done internally during authentication: normalize -> apply `roleOrder` -> first role -> `defaultRole` fallback.
+
+---
+
+## 1. Class Design
+
+### 1.1 `JWTDomainSpecificData`
+
+Package:
+`com.gip.xyna.xfmg.xopctrl.usermanagement.jwt`
+
+Implements:
+`DomainTypeSpecificData`
+
+Configuration attributes:
+
+- `List<String> trustedIssuers`
+- `List<String> intendedAudience`
+- `Optional<String> roleClaimPath`
+- `Optional<String> defaultRole`
+- `Optional<String> rolePrefix`
+- `Optional<String> roleSuffix`
+- `List<String> roleOrder` (optional, case-sensitive role priority list)
+- `Optional<String> jwksUri` (optional, otherwise OIDC discovery is used)
+- `AuthValidationMode authValidationMode` with values `HEADER|JWT` (default: `JWT`)
+
+**Supported Authentication Modes:**
+
+The `AuthValidationMode` determines how the JWT is validated:
+
+- `JWT` (default): Full signature validation is performed. The parser loads keys from the configured `jwksUri` or via OIDC discovery from the issuer's well-known endpoint. This mode requires network access to the IdP/JWKS endpoint.
+
+- `HEADER`: No signature validation is performed in Xyna; the JWT payload is decoded directly. This mode assumes a trusted reverse proxy (e.g., Apache with `mod_auth_openidc`) has already validated the token and prevented header spoofing. Issuer and audience checks are still performed.
+
+---
+
+### 1.2 `JWTUserAuthentication`
+
+**Package:**
+`com.gip.xyna.xfmg.xopctrl.usermanagement.jwt`
+
+Extends:
+`OrderBackedUserAuthentication`
+
+Role in architecture:
+
+- Creates an auth order for JWT domains.
+- Stores JWT token in order context under `xfmg.xopctrl.jwt.token`.
+- Delegates JWT claim validation and role extraction to the JSONWebToken application.
+- Translates successful `AuthenticationResult` into a local Xyna `Role`.
+
+Note:
+
+- `JWTUserAuthentication` is order-backed and no longer performs a separate role-list API step for UI selection.
+
+---
+
+### 1.3 `JSONWebTokenAuthenticationServiceOperationImpl`
+
+Package:
+`xact.http.jwt.auth.impl`
+
+Role:
+
+- Entry point for JWT authentication inside the JSONWebToken application.
+- Reads token from order context (`xfmg.xopctrl.jwt.token`).
+- Resolves domain and validates domain type (`JWT`).
+- Calls `JWTAuthenticationLogic.resolveAvailableRoles(...)` internally.
+- Chooses role with this strategy:
+  1. first role from ordered/normalized role list
+  2. otherwise `defaultRole`
+  3. otherwise authentication failure
+
+Public service surface:
+
+- `authenticate(...)` only
+- No public `resolveAvailableRoles(...)` operation is used in this architecture.
+
+---
+
+### 1.4 `JWTAuthenticationLogic`
+
+Package:
+`xact.http.jwt.auth.impl`
+
+Role:
+
+- Validates claims according to configured validation mode.
+- Enforces issuer and audience checks.
+- Extracts roles from configured claim path.
+- Normalizes roles (prefix/suffix trimming).
+- Applies `roleOrder` (case-sensitive) and appends remaining roles in token order.
+
+Role selection pipeline:
+
+1. Extract role claim via `roleClaimPath` (default `roles`)
+2. Normalize roles by prefix/suffix rules
+3. Apply `roleOrder` (case-sensitive)
+4. Return ordered roles list to authenticate flow
+
+---
+
+### 1.5 `OIDCSigningKeyResolver`
+
+Package:
+`xact.http.jwt.auth.impl`
+
+Role:
+
+- JJWT key locator for signature validation in `JWT` mode
+- Loads and caches JWKS keys
+- Uses configured `jwksUri`, or OIDC discovery via `{issuer}/.well-known/openid-configuration`
+
+Operational note:
+
+- In `JWT` mode, Xyna must reach IdP/JWKS endpoints.
+- If that is not possible, use `HEADER` mode.
+
+---
+
+## 2. Integration
+
+### 2.1 `DomainType.JWT`
+
+`DomainType.generateDomainTypeSpecificData(...)` reads JWT-specific parameters from CLI map.
+
+Required:
+
+- `ordertype`
+- `trustedIssuers`
+- `intendedAudience`
+
+Optional:
+
+- `application` (together with `version`) or `workspace` for runtime context / revision lookup
+- `version` (together with `application`)
+- `roleClaimPath`
+- `defaultRole`
+- `rolePrefix`
+- `roleSuffix`
+- `roleOrder`
+- `jwksUri`
+- `authValidationMode` (default: `JWT`)
+
+Invalid values for `authValidationMode` raise `IllegalArgumentException`.
+
+---
+
+### 2.2 Login flow via H5Xdev
+
+1. `/auth/externalUserLoginInformation`
+   - Reads external identity from configured header/certificate.
+   - Returns only:
+     - `username`
+     - `userdisplayname`
+     - `externaldomains`
+
+2. `/auth/externalUserLogin`
+   - Reads JWT token from configured header (for example `OIDC_access_token`).
+   - Calls `authorizeSession(...)`.
+   - For JWT domains, `JWTUserAuthentication.authenticateUserInternally(...)` is used.
+   - Role is selected internally during auth processing (no user-side role choice).
+
+---
+
+## 3. Configuration Examples
+
+### 3.1 Strict JWT validation (default)
+
+```bash
+./xynafactory.sh setdomaintypespecificdata \
+  -domainName JWT_DOMAIN \
+  -domainTypeSpecificData \
+  ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
+  application=JSONWebToken \
+  version=1.0.4 \
+  trustedIssuers=https://idp.example.com/realms/master \
+  intendedAudience=account \
+  authValidationMode=JWT \
+  roleClaimPath=roles \
+  defaultRole=PortalUser
+```
+
+### 3.2 Proxy-validated (`HEADER`)
+
+```bash
+./xynafactory.sh setdomaintypespecificdata \
+  -domainName JWT_DOMAIN \
+  -domainTypeSpecificData \
+  ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
+  application=JSONWebToken \
+  version=1.0.4 \
+  trustedIssuers=https://idp.example.com/realms/master \
+  intendedAudience=account \
+  authValidationMode=HEADER \
+  defaultRole=PortalUser
+```
+
+### 3.3 With role prioritization
+
+```bash
+./xynafactory.sh setdomaintypespecificdata \
+  -domainName JWT_DOMAIN \
+  -domainTypeSpecificData \
+  ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
+  application=JSONWebToken \
+  version=1.0.4 \
+  trustedIssuers=https://idp.example.com/realms/master \
+  intendedAudience=account \
+  authValidationMode=JWT \
+  roleClaimPath=roles \
+  roleOrder=Admin,SuperUser,PortalUser \
+  defaultRole=PortalUser
+```
+
+`roleOrder` is matched in configured order (case-sensitive) after normalization.
+
+---
+
+## 4. Test Cases
+
+Recommended test matrix:
+
+1. `JWT` + valid token + reachable IdP/JWKS -> success
+2. `JWT` + IdP unreachable -> authentication failure
+3. `JWT` + wrong issuer -> failure
+4. `JWT` + wrong audience -> failure
+5. `JWT` + valid token with multiple roles + `roleOrder` configured -> first matching role from `roleOrder`
+6. `JWT` + valid token with roles not in `roleOrder` -> first normalized role from token
+7. `JWT` + no extractable role + configured `defaultRole` -> default role selected
+8. `HEADER` + valid claims -> success without network access
+9. `HEADER` + missing/invalid claims -> failure
+10. H5Xdev info endpoint returns no role list fields
+
+---
+
+## 5. Security Notes
+
+- `JWT` is the safest default mode.
+- `HEADER` assumes a trusted reverse proxy (for example Apache with `mod_auth_openidc`) validates tokens and prevents header spoofing.
+- Role prioritization via `roleOrder` is applied after prefix/suffix normalization and is case-sensitive.

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -63,10 +63,6 @@ Role in architecture:
 - Delegates JWT claim validation and role extraction to the JSONWebToken application.
 - Translates successful `AuthenticationResult` into a local Xyna `Role`.
 
-Note:
-
-- `JWTUserAuthentication` is order-backed and no longer performs a separate role-list API step for UI selection.
-
 ---
 
 ### 1.3 `JSONWebTokenAuthenticationServiceOperationImpl`
@@ -244,7 +240,7 @@ Recommended test matrix:
 7. `JWT` + no extractable role + configured `defaultRole` -> default role selected
 8. `HEADER` + valid claims -> success without network access
 9. `HEADER` + missing/invalid claims -> failure
-10. H5Xdev info endpoint returns no role list fields
+
 
 ---
 

--- a/installation/build/pom.xml
+++ b/installation/build/pom.xml
@@ -558,6 +558,12 @@
               <scope>runtime</scope>
             </dependency>
             <dependency>
+              <groupId>com.auth0</groupId>
+              <artifactId>jwks-rsa</artifactId>
+              <version>0.24.1</version>
+              <scope>compile</scope>
+            </dependency>
+            <dependency>
               <groupId>io.jsonwebtoken</groupId>
               <artifactId>jjwt-api</artifactId>
               <version>0.12.6</version>

--- a/modules/xact/http/mdmimpl/HTTPResponseResolverImpl/src/xact/http/impl/HTTPResponseResolverInstanceOperationImpl.java
+++ b/modules/xact/http/mdmimpl/HTTPResponseResolverImpl/src/xact/http/impl/HTTPResponseResolverInstanceOperationImpl.java
@@ -1,0 +1,43 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+package xact.http.impl;
+
+
+import xact.http.HTTPResponseResolver;
+import xact.http.HTTPResponseResolverSuperProxy;
+
+
+public class HTTPResponseResolverInstanceOperationImpl extends HTTPResponseResolverSuperProxy {
+
+  private static final long serialVersionUID = 1L;
+
+  public HTTPResponseResolverInstanceOperationImpl(HTTPResponseResolver instanceVar) {
+    super(instanceVar);
+  }
+
+  private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
+    //change if needed to store instance context
+    s.defaultWriteObject();
+  }
+
+  private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {
+    //change if needed to restore instance-context during deserialization of order
+    s.defaultReadObject();
+  }
+
+}

--- a/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/AuthenticateWithJWT.xml
+++ b/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/AuthenticateWithJWT.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--><Service xmlns="http://www.gip.com/xyna/xdev/xfractmod" Label="Authenticate with JWT" TypeName="AuthenticateWithJWT" TypePath="xact.http.jwt.auth" Version="1.8">
+  <Operation ID="0" IsStatic="false" Label="Authenticate with JWT" Name="AuthenticateWithJWT">
+    <Input>
+      <Data ID="18" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName18"/>
+    </Input>
+    <Output>
+      <Data ID="52" Label="AuthenticationResult" ReferenceName="AuthenticationResult" ReferencePath="xfmg.xopctrl" VariableName="authenticationResult52"/>
+    </Output>
+    <ServiceReference ID="33" Label="JSON Web Token Authentication" ReferenceName="JSONWebTokenAuthentication.JSONWebTokenAuthentication" ReferencePath="xact.http.jwt.auth">
+      <Source RefID="32"/>
+      <Target RefID="32"/>
+    </ServiceReference>
+    <Function ID="32" Label="Authenticate">
+      <Source RefID="33"/>
+      <Source RefID="18"/>
+      <Target RefID="33"/>
+      <Target RefID="35"/>
+      <Invoke Operation="authenticate" ServiceID="33">
+        <Source RefID="18"/>
+      </Invoke>
+      <Receive ServiceID="33">
+        <Target RefID="35"/>
+      </Receive>
+      <Catch ExceptionID="74" ID="75">
+        <Mappings ID="89" Label="Mapping">
+          <Output>
+            <Data ID="102" Label="AuthenticationResult" ReferenceName="AuthenticationResult" ReferencePath="xfmg.xopctrl" VariableName="authenticationResult102">
+              <Source RefID="89"/>
+            </Data>
+            <Target RefID="103"/>
+          </Output>
+          <Mapping>%0%.success="false"</Mapping>
+        </Mappings>
+        <Assign>
+          <Source RefID="103"/>
+          <Target RefID="35"/>
+          <Copy>
+            <Source RefID="103"/>
+            <Target RefID="35"/>
+          </Copy>
+        </Assign>
+      </Catch>
+    </Function>
+    <Data ID="35" Label="AuthenticationResult" ReferenceName="AuthenticationResult" ReferencePath="xfmg.xopctrl" VariableName="authenticationResult35">
+      <Source RefID="32"/>
+    </Data>
+    <Data ID="103" Label="AuthenticationResult" ReferenceName="AuthenticationResult" ReferencePath="xfmg.xopctrl" VariableName="authenticationResult103">
+      <Source RefID="89"/>
+    </Data>
+    <Exception ID="74" Label="Exception" ReferenceName="Exception" ReferencePath="core.exception" VariableName="exception74">
+      <Source RefID="34"/>
+    </Exception>
+    <Assign ID="1">
+      <Source RefID="35"/>
+      <Target RefID="52"/>
+      <Copy>
+        <Source RefID="35"/>
+        <Target RefID="52"/>
+      </Copy>
+    </Assign>
+  </Operation>
+</Service>

--- a/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/JSONWebTokenAuthentication.xml
+++ b/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/JSONWebTokenAuthentication.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--><DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" IsAbstract="false" Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication" TypePath="xact.http.jwt.auth" Version="1.8">
+  <Meta>
+    <IsServiceGroupOnly>true</IsServiceGroupOnly>
+  </Meta>
+  <Libraries>JSONWebTokenAuthenticationImpl.jar</Libraries>
+  <SharedLibraries>JWT</SharedLibraries>
+  <Service Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication">
+    <Meta>
+      <AdditionalDependencies/>
+    </Meta>
+    <Operation IsStatic="true" Label="Authenticate" Name="authenticate" RequiresXynaOrder="true">
+      <Input>
+        <Data ID="2" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName2"/>
+      </Input>
+      <Output>
+        <Data ID="1" Label="AuthenticationResult" ReferenceName="AuthenticationResult" ReferencePath="xfmg.xopctrl" VariableName="authenticationResult1"/>
+      </Output>
+      <SourceCode>
+        <CodeSnippet Type="Java">return xact.http.jwt.auth.JSONWebTokenAuthenticationImpl.authenticate(correlatedXynaOrder, domainName2);</CodeSnippet>
+      </SourceCode>
+    </Operation>
+  </Service>
+</DataType>

--- a/modules/xact/jsonwebtoken/application.xml
+++ b/modules/xact/jsonwebtoken/application.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2025 Xyna GmbH, Germany
+ * Copyright 2026 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,50 +16,68 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="JSONWebToken" factoryVersion="" versionName="1.0.3" xmlVersion="1.1">
-  <ApplicationInfo>
-    <Description Lang="DE">Tools um JSON Web Tokens zu erzeugen, zu parsen und zu bearbeiten</Description>
-    <Description Lang="EN">Tools for creating, parsing and working with JSON Web Tokens</Description>
-    <RuntimeContextRequirements>
-      <RuntimeContextRequirement>
-        <ApplicationName>Http</ApplicationName>
-        <VersionName>1.5.10</VersionName>
-      </RuntimeContextRequirement>
-    </RuntimeContextRequirements>
-  </ApplicationInfo>
-  <SharedLibs>
-    <SharedLib implicitDependency="false">
-      <SharedLib>JWT</SharedLib>
-    </SharedLib>
-  </SharedLibs>
-  <XMOMEntries>
-    <XMOMEntry implicitDependency="false">
-      <FqName>xact.http.jwt.JSONWebToken</FqName>
-      <Type>DATATYPE</Type>
-    </XMOMEntry>
-    <XMOMEntry implicitDependency="true">
-      <FqName>xact.http.jwt.JWTClaims</FqName>
-      <Type>DATATYPE</Type>
-    </XMOMEntry>
-    <XMOMEntry implicitDependency="true">
-      <FqName>xact.http.jwt.JWTException</FqName>
-      <Type>EXCEPTION</Type>
-    </XMOMEntry>
-    <XMOMEntry implicitDependency="true">
-      <FqName>xact.http.jwt.JWTHeader</FqName>
-      <Type>DATATYPE</Type>
-    </XMOMEntry>
-    <XMOMEntry implicitDependency="true">
-      <FqName>xact.http.jwt.Key</FqName>
-      <Type>DATATYPE</Type>
-    </XMOMEntry>
-    <XMOMEntry implicitDependency="false">
-      <FqName>xact.http.jwt.KeyGenerator</FqName>
-      <Type>DATATYPE</Type>
-    </XMOMEntry>
-    <XMOMEntry implicitDependency="true">
-      <FqName>xact.http.jwt.PrivateClaim</FqName>
-      <Type>DATATYPE</Type>
-    </XMOMEntry>
-  </XMOMEntries>
+<Application applicationName="JSONWebToken" factoryVersion="" versionName="1.0.4" xmlVersion="1.1">
+    <ApplicationInfo>
+        <Description Lang="DE">Tools um JSON Web Tokens zu erzeugen, zu parsen und zu bearbeiten</Description>
+        <Description Lang="EN">Tools for creating, parsing and working with JSON Web Tokens</Description>
+        <RuntimeContextRequirements>
+            <RuntimeContextRequirement>
+                <ApplicationName>Http</ApplicationName>
+                <VersionName>1.5.10</VersionName>
+            </RuntimeContextRequirement>
+            <RuntimeContextRequirement>
+                <ApplicationName>UserSessionMgmt</ApplicationName>
+                <VersionName>1.0.3</VersionName>
+            </RuntimeContextRequirement>
+        </RuntimeContextRequirements>
+    </ApplicationInfo>
+    <Ordertypes>
+        <Ordertype implicitDependency="true">
+            <DestinationKey>xact.http.jwt.auth.AuthenticateWithJWT</DestinationKey>
+            <OrderContextMapping>true</OrderContextMapping>
+        </Ordertype>
+    </Ordertypes>
+    <SharedLibs>
+        <SharedLib implicitDependency="false">
+            <SharedLib>JWT</SharedLib>
+        </SharedLib>
+    </SharedLibs>
+    <XMOMEntries>
+        <XMOMEntry implicitDependency="false">
+            <FqName>xact.http.jwt.JSONWebToken</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="true">
+            <FqName>xact.http.jwt.JWTClaims</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="true">
+            <FqName>xact.http.jwt.JWTException</FqName>
+            <Type>EXCEPTION</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="true">
+            <FqName>xact.http.jwt.JWTHeader</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="true">
+            <FqName>xact.http.jwt.Key</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="false">
+            <FqName>xact.http.jwt.KeyGenerator</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="true">
+            <FqName>xact.http.jwt.PrivateClaim</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="false">
+            <FqName>xact.http.jwt.auth.AuthenticateWithJWT</FqName>
+            <Type>WORKFLOW</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="false">
+            <FqName>xact.http.jwt.auth.JSONWebTokenAuthentication</FqName>
+            <Type>DATATYPE</Type>
+        </XMOMEntry>
+    </XMOMEntries>
 </Application>

--- a/modules/xact/jsonwebtoken/build.xml
+++ b/modules/xact/jsonwebtoken/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2025 Xyna GmbH, Germany
+ * Copyright 2026 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,6 +36,9 @@
         <ant antfile="build.xml" target="build-app" inheritAll="false" dir="mdmimpl/KeyGeneratorImpl">
             <property name="target.dir" value="${target.dir}/app" />
         </ant>
+        <ant antfile="build.xml" target="build-app" inheritAll="false" dir="mdmimpl/JSONWebTokenAuthenticationImpl">
+            <property name="target.dir" value="${target.dir}/app" />
+        </ant>
         <antcall target="build-application" />
     </target>
 
@@ -43,6 +46,7 @@
         <antcall target="create-mdm-jar" />
         <supply-mdm-jar type="mdmimpl" name="JSONWebTokenImpl" />
         <supply-mdm-jar type="mdmimpl" name="KeyGeneratorImpl" />
+        <supply-mdm-jar type="mdmimpl" name="JSONWebTokenAuthenticationImpl" />
         <delete file="${basedir}/mdm.jar" />
     </target>
 

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/build.xml
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/build.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-->
+<project name="build" default="deploy" basedir=".">
+
+    <!-- this is the absolute path to the root -->
+    <pathconvert property="root.dir" >
+        <path location="${basedir}/../../../../.."/>
+    </pathconvert>
+    <property name="xmom.dir" value="${basedir}/../../XMOM" />
+
+    <property name="project.name" value="JSONWebTokenAuthenticationImpl" />
+    <property name="fqclassname" value="xact.http.jwt.auth.JSONWebTokenAuthentication" />
+    <property name="mdm.xml.path" value="xact/http/jwt/auth" />
+    <property name="mdm.xml.filename" value="JSONWebTokenAuthentication.xml" />
+    <property name="mdm.service.path" value="xact.http.jwt.auth.JSONWebTokenAuthentication" />
+
+     <target name="prepareLibs" description="Prepare Libs">
+        <ant antfile="build.xml" target="build" inheritAll="false" dir="${basedir}/../../sharedlib/JWT">
+            <property name="target.dir" value="${basedir}/lib/xyna" />
+        </ant>
+     </target>
+
+    <import file="${root.dir}/installation/build/buildService.xml" />
+
+</project>

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/pom.xml
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2025 Xyna GmbH, Germany
+ * Copyright 2026 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,11 +23,11 @@
         <version>1.0.0</version>
         <relativePath>../../../../../installation/build/pom.xml</relativePath>
     </parent>
-
+    
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.gip.xyna</groupId>
-    <artifactId>JWTSharedLib</artifactId>
-    <version>1.0.1</version>
+    <artifactId>JSONWebTokenAuthenticationImpl</artifactId>
+    <version>1.0.0</version>
     <packaging>jar</packaging>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -35,40 +35,17 @@
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
     <dependencies>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-api</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-impl</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.jsonwebtoken</groupId>
-        <artifactId>jjwt-jackson</artifactId>
-        <scope>runtime</scope>
-      </dependency>
-      <dependency>
-        <groupId>com.auth0</groupId>
-        <artifactId>jwks-rsa</artifactId>
-        <scope>runtime</scope>
-      </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.gip.xyna</groupId>
+            <artifactId>xynafactory</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.gip.xyna</groupId>
+            <artifactId>xynautils-exceptions</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationInstanceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationInstanceOperationImpl.java
@@ -15,25 +15,32 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  */
-package xact.http.impl;
+package xact.http.jwt.auth.impl;
 
 
-import xact.http.HTTPResponseResolver;
-import xact.http.HTTPResponseResolverSuperProxy;
+
+import java.lang.ClassNotFoundException;
+
+import xact.http.jwt.auth.JSONWebTokenAuthenticationSuperProxy;
+import xact.http.jwt.auth.JSONWebTokenAuthentication;
 
 
-public class HTTPResponseResolverInstanceOperationImpl extends HTTPResponseResolverSuperProxy {
+
+public class JSONWebTokenAuthenticationInstanceOperationImpl extends JSONWebTokenAuthenticationSuperProxy {
 
   private static final long serialVersionUID = 1L;
 
-  public HTTPResponseResolverInstanceOperationImpl(HTTPResponseResolver instanceVar) {
+
+  public JSONWebTokenAuthenticationInstanceOperationImpl(JSONWebTokenAuthentication instanceVar) {
     super(instanceVar);
   }
+
 
   private void writeObject(java.io.ObjectOutputStream s) throws java.io.IOException {
     //change if needed to store instance context
     s.defaultWriteObject();
   }
+
 
   private void readObject(java.io.ObjectInputStream s) throws java.io.IOException, ClassNotFoundException {
     //change if needed to restore instance-context during deserialization of order

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -1,0 +1,156 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+package xact.http.jwt.auth.impl;
+
+
+
+import java.io.Serializable;
+import java.rmi.RemoteException;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.log4j.Logger;
+
+import com.gip.xyna.CentralFactoryLogging;
+import com.gip.xyna.utils.exceptions.XynaException;
+import com.gip.xyna.xdev.xfractmod.xmdm.XynaObject.BehaviorAfterOnUnDeploymentTimeout;
+import com.gip.xyna.xdev.xfractmod.xmdm.XynaObject.ExtendedDeploymentTask;
+import com.gip.xyna.xfmg.exceptions.XFMG_UserAuthenticationFailedException;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.AuthenticationResult;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.Domain;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainType;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainName;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
+import com.gip.xyna.xprc.XynaOrderServerExtension;
+import com.gip.xyna.xprc.xpce.OrderContext;
+
+import xact.http.jwt.auth.JSONWebTokenAuthenticationServiceOperation;
+
+
+
+public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedDeploymentTask, JSONWebTokenAuthenticationServiceOperation {
+
+  private static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
+  private static final Logger logger = CentralFactoryLogging.getLogger(JSONWebTokenAuthenticationServiceOperationImpl.class);
+
+
+  public void onDeployment() throws XynaException {
+    // TODO do something on deployment, if required
+    // This is executed again on each classloader-reload, that is each
+    // time a dependent object is redeployed, for example a type of an input parameter.
+  }
+
+
+  public void onUndeployment() throws XynaException {
+    // TODO do something on undeployment, if required
+    // This is executed again on each classloader-unload, that is each
+    // time a dependent object is redeployed, for example a type of an input parameter.
+  }
+
+
+  public Long getOnUnDeploymentTimeout() {
+    // The (un)deployment runs in its own thread. The service may define a timeout
+    // in milliseconds, after which Thread.interrupt is called on this thread.
+    // If null is returned, the default timeout (defined by XynaProperty xyna.xdev.xfractmod.xmdm.deploymenthandler.timeout) will be used.
+    return null;
+  }
+
+
+  public BehaviorAfterOnUnDeploymentTimeout getBehaviorAfterOnUnDeploymentTimeout() {
+    // Defines the behavior of the (un)deployment after reaching the timeout and if this service ignores a Thread.interrupt.
+    // - BehaviorAfterOnUnDeploymentTimeout.EXCEPTION: Deployment will be aborted, while undeployment will log the exception and NOT abort.
+    // - BehaviorAfterOnUnDeploymentTimeout.IGNORE: (Un)Deployment will be continued in another thread asynchronously.
+    // - BehaviorAfterOnUnDeploymentTimeout.KILLTHREAD: (Un)Deployment will be continued after calling Thread.stop on the thread.
+    //   executing the (Un)Deployment.
+    // If null is returned, the factory default <IGNORE> will be used.
+    return null;
+  }
+
+
+  @Override
+  public AuthenticationResult authenticate(XynaOrderServerExtension arg0, DomainName arg1) {
+    // first check if is DomainType.JWT
+    OrderContext ctx = arg0.getOrderContext();
+    Domain domain = resolveDomain(arg1 == null ? null : arg1.getName());
+    if (domain == null || domain.getDomainTypeAsEnum() != DomainType.JWT || !(domain.getDomainSpecificData() instanceof JWTDomainSpecificData)) {
+      AuthenticationResult result = new AuthenticationResult();
+      result.setSuccess(false);
+      return result;
+    }
+
+    // get token from OrderContext and check
+    try {
+      Serializable tokenValue = ctx.get(ORDER_CONTEXT_KEY_JWT_TOKEN);
+      String token = tokenValue instanceof String ? (String) tokenValue : null;
+      if (token == null || token.isEmpty()) {
+        AuthenticationResult result = new AuthenticationResult();
+        result.setSuccess(false);
+        return result;
+      }
+
+      // get roles from token claim, with DomainSpecificData do JWTAuthenticationLogic.resolveAvailableRoles()
+      JWTDomainSpecificData dsd = (JWTDomainSpecificData) domain.getDomainSpecificData();
+      List<String> roles = JWTAuthenticationLogic.resolveAvailableRoles(dsd, token);
+      String role = null;
+      String roleSource = null;
+      if (roles != null && !roles.isEmpty()) {
+        role = roles.get(0);
+        roleSource = "extractedRoles";
+      } else {
+        role = dsd.getDefaultRole().map(String::trim).filter(r -> !r.isEmpty()).orElse(null);
+        roleSource = "defaultRole";
+      }
+      if (role == null || role.trim().isEmpty()) {
+        AuthenticationResult result = new AuthenticationResult();
+        result.setSuccess(false);
+        return result;
+      }
+
+      if (logger.isDebugEnabled()) {
+        logger.debug("authenticate: using role '" + role.trim() + "' for login (source=" + roleSource + ")");
+      }
+
+      AuthenticationResult result = new AuthenticationResult();
+      result.setSuccess(true);
+      result.setRole(role.trim());
+      return result;
+    } catch (XFMG_UserAuthenticationFailedException e) {
+      AuthenticationResult result = new AuthenticationResult();
+      result.setSuccess(false);
+      return result;
+    }
+  }
+
+
+  private Domain resolveDomain(String domainName) {
+    if (domainName == null || domainName.isEmpty()) {
+      return null;
+    }
+    try {
+      for (Domain domain : com.gip.xyna.XynaFactory.getInstance().getFactoryManagement().getDomains()) {
+        if (domainName.equals(domain.getName())) {
+          return domain;
+        }
+      }
+    } catch (Exception e) {
+      return null;
+    }
+    return null;
+  }
+
+}

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -20,8 +20,6 @@ package xact.http.jwt.auth.impl;
 
 
 import java.io.Serializable;
-import java.rmi.RemoteException;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Logger;

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JWTAuthenticationLogic.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JWTAuthenticationLogic.java
@@ -1,3 +1,21 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+
 package xact.http.jwt.auth.impl;
 
 

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JWTAuthenticationLogic.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JWTAuthenticationLogic.java
@@ -1,0 +1,300 @@
+package xact.http.jwt.auth.impl;
+
+
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+
+import com.gip.xyna.CentralFactoryLogging;
+import com.gip.xyna.xfmg.exceptions.XFMG_UserAuthenticationFailedException;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
+
+import io.jsonwebtoken.Claims;
+
+
+
+/**
+ * Central JWT validation and role extraction logic for the JSONWebToken application.
+ */
+public final class JWTAuthenticationLogic {
+
+  private static final Logger logger = CentralFactoryLogging.getLogger(JWTAuthenticationLogic.class);
+
+
+  private JWTAuthenticationLogic() {
+  }
+
+
+  public static List<String> resolveAvailableRoles(JWTDomainSpecificData domainSpecificData, String token)
+      throws XFMG_UserAuthenticationFailedException {
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "resolveAvailableRoles: token present=" + (token != null && !token.isEmpty()) + ", mode=" + domainSpecificData.getAuthValidationMode() + ", roleClaimPath=" + domainSpecificData.getRoleClaimPath()
+              .orElse("roles"));
+    }
+
+    Map<String, Object> claimsMap = resolveAndValidateClaims(domainSpecificData, token);
+    if (claimsMap == null) {
+      logger.info("resolveAvailableRoles: claims map is null, returning empty list");
+      return Collections.emptyList();
+    }
+
+    String rolePrefix = domainSpecificData.getRolePrefix().orElse("");
+    String roleSuffix = domainSpecificData.getRoleSuffix().orElse("");
+    List<String> roleOrder = domainSpecificData.getRoleOrder();
+    String roleClaimPath = domainSpecificData.getRoleClaimPath().orElse("roles");
+
+    if (logger.isDebugEnabled()) {
+      logger.debug(
+          "resolveAvailableRoles: using roleClaimPath=" + roleClaimPath + ", rolePrefix='" + rolePrefix + "', roleSuffix='" + roleSuffix + "', roleOrder=" + roleOrder);
+    }
+
+    List<String> roles = extractRolesFromClaims(claimsMap, roleClaimPath, rolePrefix, roleSuffix, roleOrder);
+
+    if (logger.isDebugEnabled()) {
+      logger.debug("resolveAvailableRoles: extracted roles=" + roles);
+    }
+
+    if (roles.isEmpty()) {
+      String defaultRole = domainSpecificData.getDefaultRole().orElse(null);
+      if (defaultRole != null && !defaultRole.trim().isEmpty()) {
+        if (logger.isInfoEnabled()) {
+          logger.info("resolveAvailableRoles: no roles extracted, using defaultRole=" + defaultRole.trim());
+        }
+        return Collections.singletonList(defaultRole.trim());
+      }
+      logger.warn("resolveAvailableRoles: no roles extracted and no defaultRole configured");
+    }
+    return roles;
+  }
+
+
+  private static Map<String, Object> resolveAndValidateClaims(JWTDomainSpecificData domainSpecificData, String token)
+      throws XFMG_UserAuthenticationFailedException {
+    // AuthValidationMode:
+    //  JWT:    use OIDCSigningKeyResolver to get the signing key and validate the token
+    //  HEADER: trust proxy and skip signature verification
+    JWTDomainSpecificData.AuthValidationMode mode = domainSpecificData.getAuthValidationMode();
+    Map<String, Object> claimsMap;
+    if (mode == JWTDomainSpecificData.AuthValidationMode.JWT) {
+      OIDCSigningKeyResolver keyResolver = new OIDCSigningKeyResolver(domainSpecificData);
+      Claims jwtClaims = io.jsonwebtoken.Jwts.parser().keyLocator(keyResolver).build().parseSignedClaims(token).getPayload();
+      claimsMap = new LinkedHashMap<>(jwtClaims);
+      logger.debug("JWT claims (signature verified): " + claimsMap);
+    } else {
+      claimsMap = decodePayloadWithoutVerification(token);
+      logger.debug("JWT payload decoded without signature check (HEADER mode): " + claimsMap);
+    }
+
+    String issuer = (String) claimsMap.get("iss");
+    if (issuer == null || !domainSpecificData.getTrustedIssuers().contains(issuer)) {
+      logger.warn("resolveAndValidateClaims: Untrusted issuer: " + issuer);
+      throw new XFMG_UserAuthenticationFailedException("Untrusted issuer: " + issuer);
+    }
+
+    Object audObj = claimsMap.get("aud");
+    Set<String> tokenAudiences = toStringSet(audObj);
+    if (tokenAudiences == null || domainSpecificData.getIntendedAudience().stream().noneMatch(tokenAudiences::contains)) {
+      logger.warn("resolveAndValidateClaims: Incorrect audience: " + audObj);
+      throw new XFMG_UserAuthenticationFailedException("Incorrect audience: " + audObj);
+    }
+
+    return claimsMap;
+  }
+
+
+  /**
+   * AuthValidationMode: HEADER: trust proxy and skip signature verification
+   */
+
+  private static Map<String, Object> decodePayloadWithoutVerification(String token) throws XFMG_UserAuthenticationFailedException {
+    String[] parts = token.split("\\.");
+    if (parts.length != 3) {
+      logger.warn("decodePayloadWithoutVerification: Invalid JWT format, expected 3 parts but got " + parts.length);
+      throw new XFMG_UserAuthenticationFailedException("Invalid JWT format (expected 3 parts)");
+    }
+    try {
+      byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+      String payloadJson = new String(payloadBytes, StandardCharsets.UTF_8);
+      return parseJsonToMap(payloadJson);
+    } catch (IllegalArgumentException e) {
+      logger.warn("decodePayloadWithoutVerification: Failed to decode JWT payload", e);
+      throw new XFMG_UserAuthenticationFailedException("Failed to decode JWT payload", e);
+    }
+  }
+
+
+  private static Map<String, Object> parseJsonToMap(String json) {
+    Map<String, Object> map = new LinkedHashMap<>();
+    json = json.trim();
+    if (json.startsWith("{")) {
+      json = json.substring(1);
+    }
+    if (json.endsWith("}")) {
+      json = json.substring(0, json.length() - 1);
+    }
+
+    java.util.regex.Matcher m =
+        java.util.regex.Pattern.compile("\"([^\"]+)\"\\s*:\\s*(\"([^\"]*)\"|([0-9]+)|true|false|null|\\[[^\\]]*\\])").matcher(json);
+    while (m.find()) {
+      String key = m.group(1);
+      String raw = m.group(2);
+      if (raw.startsWith("\"")) {
+        map.put(key, m.group(3));
+      } else if (raw.startsWith("[")) {
+        List<String> list = new ArrayList<>();
+        java.util.regex.Matcher am = java.util.regex.Pattern.compile("\"([^\"]+)\"").matcher(raw);
+        while (am.find()) {
+          list.add(am.group(1));
+        }
+        map.put(key, list);
+      } else {
+        map.put(key, raw);
+      }
+    }
+    return map;
+  }
+
+
+  /**
+   * extract roles from claims map with configured settings
+   */
+
+
+  private static List<String> extractRolesFromClaims(Map<String, Object> claimsMap, String claimPath, String rolePrefix, String roleSuffix,
+                                                     List<String> roleOrder) {
+    if (claimsMap == null || claimPath == null || claimPath.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Object value = resolveClaimPath(claimsMap, claimPath);
+    if (value == null) {
+      return Collections.emptyList();
+    }
+
+    boolean hasPrefix = rolePrefix != null && !rolePrefix.isEmpty();
+    boolean hasSuffix = roleSuffix != null && !roleSuffix.isEmpty();
+    LinkedHashSet<String> normalizedRoles = new LinkedHashSet<>();
+
+    if (value instanceof Collection) {
+      for (Object item : (Collection<?>) value) {
+        if (!(item instanceof String)) {
+          continue;
+        }
+        String normalized = normalizeRole(((String) item).trim(), rolePrefix, roleSuffix, hasPrefix, hasSuffix);
+        if (normalized != null) {
+          normalizedRoles.add(normalized);
+        }
+      }
+    } else if (value instanceof String) {
+      String normalized = normalizeRole(((String) value).trim(), rolePrefix, roleSuffix, hasPrefix, hasSuffix);
+      if (normalized != null) {
+        normalizedRoles.add(normalized);
+      }
+    }
+
+    if (normalizedRoles.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<String> orderedRoles = new ArrayList<>();
+    if (roleOrder != null && !roleOrder.isEmpty()) {
+      for (String preferredRole : roleOrder) {
+        if (normalizedRoles.contains(preferredRole)) {
+          orderedRoles.add(preferredRole);
+        }
+      }
+    }
+
+    for (String role : normalizedRoles) {
+      if (!orderedRoles.contains(role)) {
+        orderedRoles.add(role);
+      }
+    }
+    return orderedRoles;
+  }
+
+
+  private static String normalizeRole(String candidate, String rolePrefix, String roleSuffix, boolean hasPrefix, boolean hasSuffix) {
+    // normalizeRole: check for prefix suffix and remove it
+    if (candidate == null || candidate.isEmpty()) {
+      return null;
+    }
+    if (!matchesPrefixSuffix(candidate, rolePrefix, roleSuffix)) {
+      return null;
+    }
+
+    String normalized = candidate;
+    if (hasPrefix) {
+      normalized = normalized.substring(rolePrefix.length());
+    }
+    if (hasSuffix) {
+      normalized = normalized.substring(0, normalized.length() - roleSuffix.length());
+    }
+    return normalized;
+  }
+
+
+  private static boolean matchesPrefixSuffix(String candidate, String prefix, String suffix) {
+    // get matching roles
+    boolean hasPrefix = prefix != null && !prefix.isEmpty();
+    boolean hasSuffix = suffix != null && !suffix.isEmpty();
+
+    if (hasPrefix && hasSuffix) {
+      return candidate.startsWith(prefix) && candidate.endsWith(suffix);
+    }
+    if (hasPrefix) {
+      return candidate.startsWith(prefix);
+    }
+    if (hasSuffix) {
+      return candidate.endsWith(suffix);
+    }
+    return true;
+  }
+
+
+  private static Object resolveClaimPath(Map<String, Object> claimsMap, String claimPath) {
+    if (!claimPath.contains(".")) {
+      return claimsMap.get(claimPath);
+    }
+
+    Object current = claimsMap;
+    for (String part : claimPath.split("\\.")) {
+      if (!(current instanceof Map)) {
+        return null;
+      }
+      current = ((Map<?, ?>) current).get(part);
+      if (current == null) {
+        return null;
+      }
+    }
+    return current;
+  }
+
+
+  @SuppressWarnings("unchecked")
+  private static Set<String> toStringSet(Object aud) {
+    if (aud == null) {
+      return null;
+    }
+    Set<String> result = new java.util.HashSet<>();
+    if (aud instanceof String) {
+      result.add((String) aud);
+    } else if (aud instanceof Collection) {
+      result.addAll((Collection<String>) aud);
+    } else {
+      result.add(aud.toString());
+    }
+    return result;
+  }
+}

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
@@ -1,0 +1,119 @@
+package xact.http.jwt.auth.impl;
+
+
+
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.Key;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Logger;
+
+import com.auth0.jwk.Jwk;
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.gip.xyna.CentralFactoryLogging;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
+
+import io.jsonwebtoken.Header;
+import io.jsonwebtoken.Locator;
+import io.jsonwebtoken.ProtectedHeader;
+
+
+
+/**
+ * Fetches public keys from JWKS with caching.
+ * The JWKS URI is taken from config or auto-discovered via OIDC discovery.
+ */
+public class OIDCSigningKeyResolver implements Locator<Key> {
+
+  private static final Logger logger = CentralFactoryLogging.getLogger(OIDCSigningKeyResolver.class);
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  private final JWTDomainSpecificData domainSpecificData;
+  private volatile JwkProvider jwkProvider;
+  private final Map<String, Key> keyCache = new ConcurrentHashMap<>();
+  private volatile long keyCacheExpiryMs = 0L;
+
+
+  public OIDCSigningKeyResolver(JWTDomainSpecificData domainSpecificData) {
+    this.domainSpecificData = domainSpecificData;
+  }
+
+
+  @Override
+  public Key locate(Header header) {
+    String kid = (header instanceof ProtectedHeader) ? ((ProtectedHeader) header).getKeyId() : "";
+    try {
+      long now = System.currentTimeMillis();
+      if (now > keyCacheExpiryMs) {
+        keyCache.clear();
+        keyCacheExpiryMs = now + TimeUnit.HOURS.toMillis(24);
+        logger.debug("JWK key cache cleared/reset.");
+      }
+      return keyCache.computeIfAbsent(kid, k -> {
+        try {
+          Jwk jwk = getOrCreateProvider().get(k.isEmpty() ? null : k);
+          return jwk.getPublicKey();
+        } catch (Exception e) {
+          throw new IllegalStateException("Failed to fetch JWK for kid='" + k + "'", e);
+        }
+      });
+    } catch (Exception e) {
+      throw new IllegalStateException("No matching key found in JWKS for kid='" + kid + "'", e);
+    }
+  }
+
+
+  private synchronized JwkProvider getOrCreateProvider() throws Exception {
+    if (jwkProvider == null) {
+      String jwksUri = resolveJwksUri();
+      jwkProvider = new JwkProviderBuilder(new URL(jwksUri)).cached(false).rateLimited(false).build();
+      logger.info("JwkProvider initialized for: " + jwksUri);
+    }
+    return jwkProvider;
+  }
+
+
+  private String resolveJwksUri() throws Exception {
+    if (domainSpecificData.getJwksUri().isPresent()) {
+      String uri = domainSpecificData.getJwksUri().get();
+      logger.debug("Using configured jwksUri: " + uri);
+      return uri;
+    }
+
+    List<String> issuers = domainSpecificData.getTrustedIssuers();
+    if (issuers == null || issuers.isEmpty()) {
+      throw new IllegalStateException("No trustedIssuers configured and no jwksUri set - cannot discover JWKS URI.");
+    }
+
+    String issuer = issuers.get(0);
+    String discoveryUrl = issuer.endsWith("/") ? issuer + ".well-known/openid-configuration" : issuer + "/.well-known/openid-configuration";
+
+    logger.debug("Fetching OIDC Discovery document: " + discoveryUrl);
+    HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+    HttpResponse<String> response =
+        client.send(HttpRequest.newBuilder().uri(URI.create(discoveryUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
+                    HttpResponse.BodyHandlers.ofString());
+    if (response.statusCode() != 200) {
+      throw new IllegalStateException("HTTP " + response.statusCode() + " from " + discoveryUrl);
+    }
+
+    String jwksUri = OBJECT_MAPPER.readTree(response.body()).path("jwks_uri").asText(null);
+    if (jwksUri == null) {
+      throw new IllegalStateException("No 'jwks_uri' in OIDC Discovery response from " + discoveryUrl);
+    }
+    logger.info("Discovered jwksUri: " + jwksUri);
+    return jwksUri;
+  }
+
+}
+

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
@@ -72,7 +72,9 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
       if (now > keyCacheExpiryMs) {
         keyCache.clear();
         keyCacheExpiryMs = now + TimeUnit.HOURS.toMillis(24);
-        logger.debug("JWK key cache cleared/reset.");
+        if (logger.isDebugEnabled()) {
+          logger.debug("JWK key cache cleared/reset.");
+        }
       }
       return keyCache.computeIfAbsent(kid, k -> {
         try {
@@ -92,7 +94,9 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
     if (jwkProvider == null) {
       String jwksUri = resolveJwksUri();
       jwkProvider = new JwkProviderBuilder(new URL(jwksUri)).cached(false).rateLimited(false).build();
-      logger.info("JwkProvider initialized for: " + jwksUri);
+      if (logger.isInfoEnabled()) {
+        logger.info("JwkProvider initialized for: " + jwksUri);
+      }
     }
     return jwkProvider;
   }
@@ -101,7 +105,9 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
   private String resolveJwksUri() throws Exception {
     if (domainSpecificData.getJwksUri().isPresent()) {
       String uri = domainSpecificData.getJwksUri().get();
-      logger.debug("Using configured jwksUri: " + uri);
+      if (logger.isDebugEnabled()) {
+        logger.debug("Using configured jwksUri: " + uri);
+      }
       return uri;
     }
 
@@ -113,7 +119,9 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
     String issuer = issuers.get(0);
     String discoveryUrl = issuer.endsWith("/") ? issuer + ".well-known/openid-configuration" : issuer + "/.well-known/openid-configuration";
 
-    logger.debug("Fetching OIDC Discovery document: " + discoveryUrl);
+    if (logger.isDebugEnabled()) {
+      logger.debug("Fetching OIDC Discovery document: " + discoveryUrl);
+    }
     HttpClient client = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
     HttpResponse<String> response =
         client.send(HttpRequest.newBuilder().uri(URI.create(discoveryUrl)).timeout(Duration.ofSeconds(10)).GET().build(),
@@ -126,7 +134,9 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
     if (jwksUri == null) {
       throw new IllegalStateException("No 'jwks_uri' in OIDC Discovery response from " + discoveryUrl);
     }
-    logger.info("Discovered jwksUri: " + jwksUri);
+    if (logger.isInfoEnabled()) {
+      logger.info("Discovered jwksUri: " + jwksUri);
+    }
     return jwksUri;
   }
 

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
@@ -1,6 +1,21 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
 package xact.http.jwt.auth.impl;
-
-
 
 import java.net.URI;
 import java.net.URL;

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/OIDCSigningKeyResolver.java
@@ -66,7 +66,7 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
 
   @Override
   public Key locate(Header header) {
-    String kid = (header instanceof ProtectedHeader) ? ((ProtectedHeader) header).getKeyId() : "";
+    String keyId = (header instanceof ProtectedHeader) ? ((ProtectedHeader) header).getKeyId() : "";
     try {
       long now = System.currentTimeMillis();
       if (now > keyCacheExpiryMs) {
@@ -76,16 +76,16 @@ public class OIDCSigningKeyResolver implements Locator<Key> {
           logger.debug("JWK key cache cleared/reset.");
         }
       }
-      return keyCache.computeIfAbsent(kid, k -> {
+      return keyCache.computeIfAbsent(keyId, k -> {
         try {
           Jwk jwk = getOrCreateProvider().get(k.isEmpty() ? null : k);
           return jwk.getPublicKey();
         } catch (Exception e) {
-          throw new IllegalStateException("Failed to fetch JWK for kid='" + k + "'", e);
+          throw new IllegalStateException("Failed to fetch JWK for keyId='" + k + "'", e);
         }
       });
     } catch (Exception e) {
-      throw new IllegalStateException("No matching key found in JWKS for kid='" + kid + "'", e);
+      throw new IllegalStateException("No matching key found in JWKS for keyId='" + keyId + "'", e);
     }
   }
 

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/xmldefinition/JSONWebTokenAuthentication.xml
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/xmldefinition/JSONWebTokenAuthentication.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+--><DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" IsAbstract="false" Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication" TypePath="xact.http.jwt.auth" Version="1.8">
+  <Meta>
+    <IsServiceGroupOnly>true</IsServiceGroupOnly>
+  </Meta>
+  <Libraries>JSONWebTokenAuthenticationImpl.jar</Libraries>
+  <Service Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication">
+    <Operation IsStatic="true" Label="Authenticate" Name="authenticate">
+      <Input>
+        <Data ID="2" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName2"/>
+      </Input>
+      <Output>
+        <Data ID="1" Label="AuthenticationResult" ReferenceName="AuthenticationResult" ReferencePath="xfmg.xopctrl" VariableName="authenticationResult1"/>
+      </Output>
+      <SourceCode>
+        <CodeSnippet Type="Java">return JSONWebTokenAuthenticationImpl.authenticate(domainName2);</CodeSnippet>
+      </SourceCode>
+    </Operation>
+  </Service>
+</DataType>

--- a/modules/xdev/yang/application.xml
+++ b/modules/xdev/yang/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.3</VersionName>
+        <VersionName>1.5.4</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>YangBase</ApplicationName>

--- a/modules/xmcp/gitIntegration/application.xml
+++ b/modules/xmcp/gitIntegration/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.3</VersionName>
+        <VersionName>1.5.4</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xmcp/guihttp/application.xml
+++ b/modules/xmcp/guihttp/application.xml
@@ -17,7 +17,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <!--                                               ################# Version auch in blackedition_lib.sh updaten ########### -->
-<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.5.3" xmlVersion="1.1">
+<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.5.4" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">Interne Funktionalität zum Interagieren des Xyna Fractal Modellers mit dem Xyna Factory Server</Description>
     <Description Lang="EN">Internal functionality for interaction of the Xyna Fractal Modeller with the Xyna Factory Server</Description>

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilter.java
@@ -66,6 +66,7 @@ import com.gip.xyna.xact.filter.xmom.datatypes.json.GuiHttpPluginManagement;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection.Method;
 import com.gip.xyna.xdev.xfractmod.xmdm.ConnectionFilter;
+import com.gip.xyna.xdev.xfractmod.xmdm.FilterConfigurationParameter;
 import com.gip.xyna.xdev.xfractmod.xmdm.EventListener;
 import com.gip.xyna.xdev.xfractmod.xmdm.GeneralXynaObject;
 import com.gip.xyna.xfmg.xfctrl.appmgmt.RevisionOrderControl;
@@ -143,6 +144,13 @@ public class H5XdevFilter extends ConnectionFilter<HTTPTriggerConnection> {
   public static final XynaPropertyBoolean SUPPRESS_STACKTRACES = new XynaPropertyBoolean("xmcp.guihttp.suppress_stacktraces", false)
       .setDefaultDocumentation(DocumentationLanguage.EN, "Remove stacktraces from error responses.")
       .setDefaultDocumentation(DocumentationLanguage.DE, "Entferne Stacktraces aus Fehlern in Antwortnachrichten.");
+
+  private H5XdevFilterParameter config;
+
+  @Override
+  public FilterConfigurationParameter createFilterConfigurationTemplate() {
+    return new H5XdevFilterParameter();
+  }
 
   private static class WorkspaceRevisionBuilder implements XynaPropertyBuilds.Builder<Long> {
 
@@ -467,6 +475,22 @@ public class H5XdevFilter extends ConnectionFilter<HTTPTriggerConnection> {
     XmomUndoRedoHistory.UNDO_LIMIT.unregister();
   }
 
+  @Override
+  public FilterResponse createXynaOrder(HTTPTriggerConnection tc, FilterConfigurationParameter params) throws XynaException {
+
+    if (params != null && !params.equals(config)) {
+      if (logger.isInfoEnabled()) {
+        logger.info("Updating H5Xdev filter configuration: " + (config != null ? config : "none") + " => "+ params);
+      }
+
+      config = (H5XdevFilterParameter)params;
+
+      ExternalUserLoginAction.setExternalAuthType(config.getExternalAuthType());
+      ExternalUserLoginAction.setAuthTokenHeaderName(config.getExternalAuthHeader());
+    }
+
+    return createXynaOrder(tc);
+  }
 
   /**
    * Analyzes TriggerConnection and creates XynaOrder if it accepts the connection.

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
@@ -1,0 +1,81 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2025 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+package com.gip.xyna.xact.filter;
+
+import java.util.List;
+import java.util.Map;
+import com.gip.xyna.utils.misc.Documentation;
+import com.gip.xyna.utils.misc.StringParameter;
+import com.gip.xyna.xact.exceptions.XACT_InvalidFilterConfigurationParameterValueException;
+import com.gip.xyna.xdev.xfractmod.xmdm.FilterConfigurationParameter;
+
+import com.gip.xyna.xact.filter.actions.auth.ExternalUserLoginAction.ExternalAuthType;
+
+public class H5XdevFilterParameter extends FilterConfigurationParameter {
+
+  private static final long serialVersionUID = 1L;
+
+  public static final StringParameter<ExternalAuthType> AUTH_TYPE = StringParameter.typeEnum(ExternalAuthType.class, "externalAuthType", true)
+          .documentation(Documentation
+                  .de("Art der externen Authentifizierung.")
+                  .en("Type of external authentication.")
+                  .build())
+          .optional().defaultValue(ExternalAuthType.CLIENT_CERT).build();
+
+  public static final StringParameter<String> AUTH_HEADER = StringParameter.typeString("externalAuthHeader")
+          .documentation(Documentation
+                  .de("Name des HTTP Headers mit den Informationen für die externe Authentifizierung.")
+                  .en("Name of the HTTP header containing the data for external authentification.")
+                  .build())
+          .optional().defaultValue("SSL_CLIENT_CERT").build();
+
+  protected static final List<StringParameter<?>> ALL_PARAMETERS = 
+    StringParameter.asList( AUTH_TYPE, AUTH_HEADER );
+
+  private ExternalAuthType authType;
+  private String authHeader;
+
+  @Override
+  public List<StringParameter<?>> getAllStringParameters() {
+    return ALL_PARAMETERS;
+  }
+
+   @Override
+  public H5XdevFilterParameter build(Map<String, Object> paramMap) throws XACT_InvalidFilterConfigurationParameterValueException {
+    H5XdevFilterParameter param = new H5XdevFilterParameter();
+    param.authType = AUTH_TYPE.getFromMap(paramMap);
+    param.authHeader = AUTH_HEADER.getFromMap(paramMap);
+    return param;
+  }
+
+  public ExternalAuthType getExternalAuthType() {
+    return authType;
+  }
+  
+  public String getExternalAuthHeader() {
+    return authHeader;
+  }
+
+  @Override
+  public String toString() {
+    return "H5XdevFilterParameter{" +
+            "authType=" + authType +
+            ", authHeader='" + authHeader + '\'' +
+            '}';
+}
+}

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserInfo.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserInfo.java
@@ -101,6 +101,37 @@ public class ExternalUserInfo {
     }
   }
 
+  public static ExternalUserInfo createFromJWT(String jwt) {
+    if (jwt == null || jwt.isEmpty()) {
+        return null;
+    }
+
+    // Split the JWT into its components: header, payload, and signature
+    String[] parts = jwt.split("\\.");
+    if (parts.length != 3) {
+        return null;
+    }
+
+    // Decode the payload (Base64 URL-decoded)
+    String payload = new String(java.util.Base64.getUrlDecoder().decode(parts[1]));
+
+    // Extract the email claim from the payload
+    String emailKey = "\"email\":\"";
+    int emailStart = payload.indexOf(emailKey);
+    if (emailStart == -1) {
+        return null;
+    }
+
+    emailStart += emailKey.length();
+    int emailEnd = payload.indexOf("\"", emailStart);
+    if (emailEnd == -1) {
+        return null;
+    }
+
+    String email = payload.substring(emailStart, emailEnd);
+    String user_displayname = email.substring(0, email.indexOf('@'));
+    return new ExternalUserInfo(email, user_displayname, jwt);
+  }
 
   private static String getFromLdapName(LdapName ldapname, String key) {
     for (Rdn rdn : ldapname.getRdns()) {

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
@@ -21,6 +21,7 @@ package com.gip.xyna.xact.filter.actions.auth;
 
 import java.rmi.RemoteException;
 import java.security.cert.CertificateException;
+
 import org.apache.log4j.Logger;
 
 import com.gip.xyna.CentralFactoryLogging;
@@ -77,12 +78,24 @@ public class ExternalUserLoginAction implements FilterAction {
   }
   
   private XMOMGui xmomgui;
-  
+  private static String headerName = SSL_CLIENT_CERT;
+  private static ExternalAuthType loginType = ExternalAuthType.CLIENT_CERT;
+
+  public static enum ExternalAuthType {
+    CLIENT_CERT, JSON_WEB_TOKEN;
+  }
+
   public ExternalUserLoginAction(XMOMGui xmomgui) {
     this.xmomgui = xmomgui;
   }
 
+  public static void setExternalAuthType(ExternalAuthType type) {
+    loginType = type;
+  }
 
+  public static void setAuthTokenHeaderName(String value) {
+    headerName = value.toLowerCase();
+  }
 
   @Override
   public boolean match(URLPath url, Method method) {
@@ -98,9 +111,21 @@ public class ExternalUserLoginAction implements FilterAction {
 
   public static Pair<Boolean, ExternalUserInfo> getExternalUserInfoOrFail(JsonFilterActionInstance jfai, HTTPTriggerConnection tc)
       throws XynaException {
-    String client_cert = tc.getHeader().getProperty(SSL_CLIENT_CERT);
+    String header = tc.getHeader().getProperty(headerName);
     try {
-      ExternalUserInfo eui = ExternalUserInfo.createFromClientCertificate(client_cert);
+      if (logger.isDebugEnabled()) {
+        logger.debug("getting user info for " + loginType + " from " + headerName + " with value " + header);
+      }
+      ExternalUserInfo eui;
+      switch (loginType) {
+        case JSON_WEB_TOKEN:
+          String jwtHeader = header == null ? null : header.replaceFirst("Bearer\\s+", "");
+          eui = ExternalUserInfo.createFromJWT(jwtHeader);
+          break;
+        case CLIENT_CERT:
+        default:
+          eui = ExternalUserInfo.createFromClientCertificate(header);
+      }
       return Pair.of(false, eui);
     } catch (RuntimeException e) {
       Utils.logError("Unexpected failure", e);

--- a/modules/xmcp/xypilot/application.xml
+++ b/modules/xmcp/xypilot/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.3</VersionName>
+        <VersionName>1.5.4</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>XyPilotMetricsDefaults</ApplicationName>

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
@@ -20,6 +20,7 @@ package com.gip.xyna.xfmg.xopctrl.usermanagement;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import com.gip.xyna.CentralFactoryLogging;
 import com.gip.xyna.XynaFactory;
@@ -39,6 +40,7 @@ import com.gip.xyna.xfmg.xopctrl.usermanagement.ldap.LDAPServer;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.ldap.LDAPUserAuthentication;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.ldap.SSLKeyAndTruststoreParameter;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.ldap.SSLKeystoreParameter;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.*;
 import com.gip.xyna.xnwh.exceptions.XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY;
 
 
@@ -169,8 +171,111 @@ public enum DomainType {
       }
       return sslBuilder.instance();
     }
+  },
+  JWT("JWT") {
+
+    public final static String JWT_SPECIFIC_ORDERTYPE_PARAMETER_IDENTIFIER = "ordertype";
+    public final static String JWT_SPECIFIC_WORKSPACE_PARAMETER_IDENTIFIER = "workspace";
+    public final static String JWT_SPECIFIC_APPLICATION_PARAMETER_IDENTIFIER = "application";
+    public final static String JWT_SPECIFIC_VERSION_PARAMETER_IDENTIFIER = "version";
+
+    @Override
+    public JWTUserAuthentication generateAuthenticationMethod(Domain domain) {
+      return new JWTUserAuthentication(domain);
+    }
+
+    @Override
+    public JWTDomainSpecificData generateDomainTypeSpecificData(Map<String, List<String>> specifics) {
+      List<String> ordertype = specifics.get(JWT_SPECIFIC_ORDERTYPE_PARAMETER_IDENTIFIER);
+      if (ordertype == null || ordertype.isEmpty()) {
+        throw new IllegalArgumentException("No ordertype for authentification!");
+      } else if (ordertype.size() > 1) {
+        throw new IllegalArgumentException("Too many ordertypes!");
+      }
+
+      long revision = -1;
+      List<String> applications = specifics.get(JWT_SPECIFIC_APPLICATION_PARAMETER_IDENTIFIER);
+      List<String> versions = specifics.get(JWT_SPECIFIC_VERSION_PARAMETER_IDENTIFIER);
+      List<String> workspaces = specifics.get(JWT_SPECIFIC_WORKSPACE_PARAMETER_IDENTIFIER);
+      RuntimeContext rc = null;
+      if (applications != null && !applications.isEmpty() && versions != null && !versions.isEmpty()) {
+        rc = new Application(applications.get(0), versions.get(0));
+      } else if (workspaces != null && !workspaces.isEmpty()) {
+        rc = new Workspace(workspaces.get(0));
+      }
+      if (rc != null) {
+        RevisionManagement revisionManagement = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getRevisionManagement();
+        try {
+          revision = revisionManagement.getRevision(rc);
+        } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e) {
+          CentralFactoryLogging.getLogger(UserManagement.class).warn("Failed to retrieve revision for RuntimeContext " + rc, e);
+          throw new RuntimeException(e);
+        }
+      }
+
+      List<String> trustedIssuers = specifics.get("trustedIssuers");
+      if (trustedIssuers == null || trustedIssuers.isEmpty()) {
+        throw new IllegalArgumentException("No trusted issuers provided for JWT domain!");
+      }
+      List<String> intendedAudience = specifics.get("intendedAudience");
+      if (intendedAudience == null || intendedAudience.isEmpty()) {
+        throw new IllegalArgumentException("No intended audience provided for JWT domain!");
+      }
+      List<String> jwksUriList = specifics.get("jwksUri");
+      Optional<String> jwksUri = (jwksUriList != null && !jwksUriList.isEmpty())
+          ? Optional.of(jwksUriList.get(0))
+          : Optional.empty();
+      List<String> rolePrefixList = specifics.get("rolePrefix");
+      Optional<String> rolePrefix = (rolePrefixList != null && !rolePrefixList.isEmpty())
+          ? Optional.of(rolePrefixList.get(0))
+          : Optional.empty();
+      List<String> roleSuffixList = specifics.get("roleSuffix");
+      Optional<String> roleSuffix = (roleSuffixList != null && !roleSuffixList.isEmpty())
+          ? Optional.of(roleSuffixList.get(0))
+          : Optional.empty();
+      List<String> roleOrder = specifics.get("roleOrder");
+      if (roleOrder != null) {
+        List<String> cleanedRoleOrder = new ArrayList<String>();
+        for (String role : roleOrder) {
+          if (role != null) {
+            for (String part : role.split(",")) {
+              String trimmedRole = part.trim();
+              if (!trimmedRole.isEmpty()) {
+                cleanedRoleOrder.add(trimmedRole);
+              }
+            }
+          }
+        }
+        roleOrder = cleanedRoleOrder;
+      }
+      List<String> roleClaimPathList = specifics.get("roleClaimPath");
+      Optional<String> roleClaimPath = (roleClaimPathList != null && !roleClaimPathList.isEmpty())
+          ? Optional.of(roleClaimPathList.get(0))
+          : Optional.empty();
+      List<String> defaultRoleList = specifics.get("defaultRole");
+      Optional<String> defaultRole = (defaultRoleList != null && !defaultRoleList.isEmpty())
+          ? Optional.of(defaultRoleList.get(0))
+          : Optional.empty();
+
+      JWTDomainSpecificData.AuthValidationMode authValidationMode = null;
+      List<String> validationModeList = specifics.get("authValidationMode");
+      if (validationModeList != null && !validationModeList.isEmpty()) {
+        try {
+          authValidationMode = JWTDomainSpecificData.AuthValidationMode.valueOf(validationModeList.get(0).trim().toUpperCase());
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("Invalid authValidationMode: '" + validationModeList.get(0)
+              + "'. Allowed values: JWT or HEADER.");
+        }
+      }
+
+      JWTDomainSpecificData data = new JWTDomainSpecificData(trustedIssuers, intendedAudience, roleClaimPath, defaultRole,
+          rolePrefix, roleSuffix, roleOrder, jwksUri, ordertype.get(0), revision);
+      if (authValidationMode != null) {
+        data.setAuthValidationMode(authValidationMode);
+      }
+      return data;
+    }
   };
-  
 
 
   private final String name;

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
@@ -1,3 +1,20 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
 package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
 
 import java.util.List;

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
@@ -1,0 +1,186 @@
+package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.gip.xyna.CentralFactoryLogging;
+import com.gip.xyna.XynaFactory;
+import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RevisionManagement;
+import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
+import com.gip.xyna.xfmg.xopctrl.DomainTypeSpecificData;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.UserManagement;
+import com.gip.xyna.xnwh.exceptions.XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY;
+
+public class JWTDomainSpecificData implements DomainTypeSpecificData {
+
+    private static final long serialVersionUID = 7177523157271609582L;
+
+    public enum AuthValidationMode {
+        HEADER,
+        JWT
+    }
+
+    private List<String> trustedIssuers;
+    private List<String> intendedAudience;
+    private String roleClaimPath;
+    private String defaultRole;
+    private String rolePrefix;
+    private String roleSuffix;
+    private List<String> roleOrder;
+    private String jwksUri;
+    private String authValidationMode = AuthValidationMode.JWT.name();
+    private String associatedOrdertype;
+    private long revision;
+    private transient RuntimeContext runtimeContext;
+
+    public JWTDomainSpecificData() {}
+
+    public JWTDomainSpecificData(List<String> trustedIssuers, List<String> intendedAudience,
+                                 Optional<String> roleClaimPath, Optional<String> defaultRole,
+                                 Optional<String> rolePrefix, Optional<String> roleSuffix,
+                                 List<String> roleOrder, Optional<String> jwksUri,
+                                 String associatedOrdertype, long revision) {
+        this.trustedIssuers = trustedIssuers;
+        this.intendedAudience = intendedAudience;
+        this.roleClaimPath = roleClaimPath.orElse(null);
+        this.defaultRole = defaultRole.orElse(null);
+        this.rolePrefix = rolePrefix.orElse(null);
+        this.roleSuffix = roleSuffix.orElse(null);
+        this.roleOrder = roleOrder;
+        this.jwksUri = jwksUri.orElse(null);
+        this.associatedOrdertype = associatedOrdertype;
+        this.revision = revision;
+    }
+
+    public AuthValidationMode getAuthValidationMode() {
+        try {
+            return AuthValidationMode.valueOf(Optional.ofNullable(authValidationMode).orElse(AuthValidationMode.JWT.name()));
+        } catch (IllegalArgumentException e) {
+            return AuthValidationMode.JWT;
+        }
+    }
+
+    public void setAuthValidationMode(AuthValidationMode mode) {
+        this.authValidationMode = (mode != null ? mode : AuthValidationMode.JWT).name();
+    }
+
+    public String getAssociatedOrdertype() {
+        return associatedOrdertype;
+    }
+
+    public void setAssociatedOrdertype(String associatedOrdertype) {
+        this.associatedOrdertype = associatedOrdertype;
+    }
+
+    public long getRevision() {
+        return revision;
+    }
+
+    public void setRevision(long revision) {
+        this.revision = revision;
+    }
+
+    public RuntimeContext getRuntimeContext() {
+        if (runtimeContext == null) {
+            RevisionManagement revisionManagement = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getRevisionManagement();
+            try {
+                runtimeContext = revisionManagement.getRuntimeContext(revision);
+            } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e) {
+                CentralFactoryLogging.getLogger(UserManagement.class).warn("Failed to restore RuntimeContext for revision " + revision, e);
+                try {
+                    return revisionManagement.getRuntimeContext(-1L);
+                } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e1) {
+                    throw new RuntimeException("Failed to resolve default revision.");
+                }
+            }
+        }
+        return runtimeContext;
+    }
+
+    public List<String> getTrustedIssuers() {
+        return trustedIssuers;
+    }
+
+    public void setTrustedIssuers(List<String> trustedIssuers) {
+        this.trustedIssuers = trustedIssuers;
+    }
+
+    public List<String> getIntendedAudience() {
+        return intendedAudience;
+    }
+
+    public void setIntendedAudience(List<String> intendedAudience) {
+        this.intendedAudience = intendedAudience;
+    }
+
+    public Optional<String> getRoleClaimPath() {
+        return Optional.ofNullable(roleClaimPath);
+    }
+
+    public void setRoleClaimPath(Optional<String> roleClaimPath) {
+        this.roleClaimPath = roleClaimPath.orElse(null);
+    }
+
+    public Optional<String> getDefaultRole() {
+        return Optional.ofNullable(defaultRole);
+    }
+
+    public void setDefaultRole(Optional<String> defaultRole) {
+        this.defaultRole = defaultRole.orElse(null);
+    }
+
+    public Optional<String> getRolePrefix() {
+        return Optional.ofNullable(rolePrefix);
+    }
+
+    public void setRolePrefix(Optional<String> rolePrefix) {
+        this.rolePrefix = rolePrefix.orElse(null);
+    }
+
+    public Optional<String> getRoleSuffix() {
+        return Optional.ofNullable(roleSuffix);
+    }
+
+    public void setRoleSuffix(Optional<String> roleSuffix) {
+        this.roleSuffix = roleSuffix.orElse(null);
+    }
+
+    public List<String> getRoleOrder() {
+        return roleOrder;
+    }
+
+    public void setRoleOrder(List<String> roleOrder) {
+        this.roleOrder = roleOrder;
+    }
+
+    public Optional<String> getJwksUri() { return Optional.ofNullable(jwksUri); }
+
+    public void setJwksUri(Optional<String> jwksUri) { this.jwksUri = jwksUri.orElse(null); }
+
+    @Override
+    public void appendInformation(StringBuilder output) {
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+              .append("Trusted Issuers: ").append(trustedIssuers).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+              .append("Intended Audience: ").append(intendedAudience).append("\n");
+        AuthValidationMode mode = getAuthValidationMode();
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+              .append("Auth Validation Mode: ").append(mode)
+              .append(mode == AuthValidationMode.JWT ? " (default)" : "").append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+              .append("Role Claim Path: ").append(getRoleClaimPath().orElse("Not Configured")).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Default Role: ").append(getDefaultRole().orElse("Not Configured")).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Role Prefix: ").append(getRolePrefix().orElse("Not Configured")).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Role Suffix: ").append(getRoleSuffix().orElse("Not Configured")).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Role Order: ").append(roleOrder != null && !roleOrder.isEmpty() ? roleOrder : "Not Configured").append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("JWKS URI: ").append(getJwksUri().orElse("Not Configured (auto-discover)")).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Associated Order Type: ").append(associatedOrdertype).append(" @rev_").append(revision).append("\n");
+    }
+
+}

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTUserAuthentication.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTUserAuthentication.java
@@ -1,0 +1,93 @@
+package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
+
+import org.apache.log4j.Logger;
+
+import com.gip.xyna.CentralFactoryLogging;
+import com.gip.xyna.XynaFactory;
+import com.gip.xyna.xfmg.exceptions.XFMG_UserAuthenticationFailedException;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.AuthenticationResult;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.Domain;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainName;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.OrderBackedUserAuthentication;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.Role;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.UserManagement;
+import com.gip.xyna.xprc.XynaOrder;
+import com.gip.xyna.xprc.XynaOrderCreationParameter;
+import com.gip.xyna.xprc.XynaOrderServerExtension;
+import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
+
+public class JWTUserAuthentication extends OrderBackedUserAuthentication {
+
+    public static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
+    private static final Logger logger = CentralFactoryLogging.getLogger(JWTUserAuthentication.class);
+
+    private final JWTDomainSpecificData domainSpecificData;
+    private final String domainName;
+
+    public JWTUserAuthentication(Domain domain) {
+        super(domain);
+        this.domainSpecificData = (JWTDomainSpecificData) domain.getDomainSpecificData();
+        this.domainName = domain.getName();
+    }
+
+    public JWTUserAuthentication(JWTDomainSpecificData domainSpecificData) {
+        super(null);
+        this.domainSpecificData = domainSpecificData;
+        this.domainName = null;
+    }
+
+
+    @Override
+    public XynaOrder generateAuthOrder(String username, String password, Domain domain, int retry) {
+        DomainName domainName = new DomainName(domain.getName());
+        DestinationKey dk = new DestinationKey(domainSpecificData.getAssociatedOrdertype(), domainSpecificData.getRuntimeContext());
+        XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(dk, domainName);
+        XynaOrderServerExtension xo = new XynaOrderServerExtension(xocp);
+        xo.setNewOrderContext();
+        xo.getOrderContext().set(ORDER_CONTEXT_KEY_JWT_TOKEN, password);
+        return xo;
+    }
+
+
+    @Override
+    public Role handleResponse(AuthenticationResult result) throws XFMG_UserAuthenticationFailedException {
+        if (result != null && result.wasSuccesfull()) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("JWT authentication succeeded for user '" + username + "' in domain '" + domainName + "'.");
+            }
+            try {
+                return XynaFactory.getPortalInstance().getXynaMultiChannelPortalPortal()
+                    .getRole(result.getRole(), UserManagement.PREDEFINED_LOCALDOMAIN_NAME);
+            } catch (Exception e) {
+                logger.warn("JWT authentication returned role '" + result.getRole() + "' which could not be resolved.", e);
+                throw new XFMG_UserAuthenticationFailedException(username, e);
+            }
+        }
+        if (logger.isDebugEnabled()) {
+            logger.debug("JWT authentication failed for user '" + username + "' in domain '" + domainName + "'.");
+        }
+        return null;
+    }
+
+
+    @Override
+    public Role handleError(Throwable exception) throws XFMG_UserAuthenticationFailedException {
+        logger.warn("JWT authentication order execution failed for user '" + username + "'.", exception);
+        return null;
+    }
+
+
+    public String getConfiguredDefaultRole() {
+        String defaultRole = domainSpecificData.getDefaultRole().orElse(null);
+        if (defaultRole == null) {
+            return null;
+        }
+        String trimmed = defaultRole.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+
+
+
+
+
+}

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTUserAuthentication.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTUserAuthentication.java
@@ -1,3 +1,20 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
 package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
 
 import org.apache.log4j.Logger;


### PR DESCRIPTION
this pull request replaces https://github.com/Xyna-Factory/xyna-factory/pull/2393

updated with integration into JSONWebToken Application

---

new JWT domain with two validation modes via authValidationMode:

JWT (full signature validation using JJWT + JWKS/OIDC, default)
HEADER (local claim parsing without signature validation in Xyna)
In both modes, issuer and audience checks remain enforced to preserve core claim validation.
role prioritization through roleOrder: after prefix/suffix normalization, roles are matched case-sensitively in configured order, with fallback to the first token role or defaultRole.

Configuration is integrated through setdomaintypespecificdata (including optional jwksUri) and is used in the /auth/externalUserLogin flow for JWT domains.

Operationally, JWT requires network access to IdP/JWKS endpoints, while HEADER targets trusted reverse-proxy validation setup