### PR TITLE
Feature jwt role selection

### DIFF
--- a/blackedition/blackedition_lib.sh
+++ b/blackedition/blackedition_lib.sh
@@ -31,7 +31,7 @@ GUIHTTP_APP="GuiHttp"
 #ACHTUNG: Version auch bei addRequirement zu default workspace berücksichtigen
 ALL_APPLICATIONS="Base Processing"; #Default-Applications, die immer installiert sein sollten
 APPMGMTVERSION=1.0.11
-GUIHTTPVERSION=1.5.5
+GUIHTTPVERSION=1.5.6
 SNMPSTATVERSION=1.0.4
 PROCESSINGVERSION=1.0.28
 ALL_REPOSITORYACCESSES=("svn");

--- a/blackedition/blackedition_lib.sh
+++ b/blackedition/blackedition_lib.sh
@@ -31,7 +31,7 @@ GUIHTTP_APP="GuiHttp"
 #ACHTUNG: Version auch bei addRequirement zu default workspace berücksichtigen
 ALL_APPLICATIONS="Base Processing"; #Default-Applications, die immer installiert sein sollten
 APPMGMTVERSION=1.0.11
-GUIHTTPVERSION=1.5.6
+GUIHTTPVERSION=1.5.7
 SNMPSTATVERSION=1.0.4
 PROCESSINGVERSION=1.0.28
 ALL_REPOSITORYACCESSES=("svn");

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -12,7 +12,7 @@ The mode is selected through domain-specific data (`setdomaintypespecificdata`).
 
 - JWT domain setup for the order-backed flow also requires an `ordertype` and optionally a runtime context (`application` + `version` or `workspace`) to resolve the revision.
 - The JSONWebToken application exposes `authenticate` for this flow.
-- It is possible for the JWT domain to choose a role in the login form via dropdown. For old gui versions, the fallback takes place in the `resolveAvailableRoles` method of the domain. For new gui versions, the fallback takes place.
+- It is possible for the JWT domain to choose a role in the login form via dropdown. For new gui versions, the role selection is part of the login request and validated server-side.
 - If no role was selected, role selection is done internally during authentication: normalize -> apply `roleOrder` -> first role -> `defaultRole` fallback.
 
 ---
@@ -235,7 +235,7 @@ POST /auth/externalUserLogin
   defaultRole=PortalUser
 ```
 
-`ordertype` is omitted here ? `xact.http.jwt.auth.AuthenticateWithJWT` is used by default.
+`ordertype` is omitted here and `xact.http.jwt.auth.AuthenticateWithJWT` is used by default.
 
 ### 3.2 Proxy-validated (`HEADER`)
 

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -37,7 +37,11 @@ Configuration attributes:
 - `Optional<String> roleSuffix`
 - `List<String> roleOrder` (optional, case-sensitive role priority list)
 - `Optional<String> jwksUri` (optional, otherwise OIDC discovery is used)
+- `Optional<String> rolesResolverOrdertype` (optional, default: `xact.http.jwt.auth.ResolveAvailableRolesWithJWT`)
 - `AuthValidationMode authValidationMode` with values `HEADER|JWT` (default: `JWT`)
+
+`rolesResolverOrdertype` uses the same `RuntimeContext`/revision source as the JWT `ordertype`
+(from `application+version` or `workspace`).
 
 **Supported Authentication Modes:**
 
@@ -173,6 +177,7 @@ Optional:
 - `roleSuffix`
 - `roleOrder`
 - `jwksUri`
+- `rolesResolverOrdertype` (default: `xact.http.jwt.auth.ResolveAvailableRolesWithJWT`)
 - `authValidationMode` (default: `JWT`)
 
 Invalid values for `authValidationMode` raise `IllegalArgumentException`.
@@ -187,7 +192,7 @@ Invalid values for `authValidationMode` raise `IllegalArgumentException`.
      - `username`
      - `userdisplayname`
      - `externaldomains` (legacy, for backward compatibility)
-     - `domains` - list of `{ name, roles[] }` with available roles per domain, resolved via `ResolveAvailableRolesWithJWT` workflow
+     - `domains` - list of `{ name, roles[] }` with available roles per domain, resolved via `rolesResolverOrdertype` (or default `ResolveAvailableRolesWithJWT`)
 
 2. `/auth/externalUserLogin`
    - Reads JWT token from configured header (for example `OIDC_access_token`).

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -12,7 +12,8 @@ The mode is selected through domain-specific data (`setdomaintypespecificdata`).
 
 - JWT domain setup for the order-backed flow also requires an `ordertype` and optionally a runtime context (`application` + `version` or `workspace`) to resolve the revision.
 - The JSONWebToken application exposes `authenticate` for this flow.
-- Role selection is done internally during authentication: normalize -> apply `roleOrder` -> first role -> `defaultRole` fallback.
+- It is possible for the JWT domain to choose a role in the login form via dropdown. For old gui versions, the fallback takes place in the `resolveAvailableRoles` method of the domain. For new gui versions, the fallback takes place.
+- If no role was selected, role selection is done internally during authentication: normalize -> apply `roleOrder` -> first role -> `defaultRole` fallback.
 
 ---
 
@@ -60,8 +61,28 @@ Role in architecture:
 
 - Creates an auth order for JWT domains.
 - Stores JWT token in order context under `xfmg.xopctrl.jwt.token`.
+- If a `selectedRole` was passed by the caller, stores it in order context under `xfmg.xopctrl.jwt.selectedRole`.
 - Delegates JWT claim validation and role extraction to the JSONWebToken application.
 - Translates successful `AuthenticationResult` into a local Xyna `Role`.
+
+**selectedRole encoding:**
+
+Because the authentication infrastructure only provides a single `password` field, an optional `selectedRole` is encoded into the password string using a `\0` separator:
+
+```
+password = "selectedRole\0jwtToken"   (if role was selected)
+password = "jwtToken"                 (if no role was selected ? backward compatible)
+```
+
+`\0` is safe here because JWT tokens are base64url-encoded and never contain this character.
+`generateAuthOrder` splits on `\0` and sets both context keys independently.
+
+Order context keys:
+
+| Key | Value |
+|---|---|
+| `xfmg.xopctrl.jwt.token` | the actual JWT token |
+| `xfmg.xopctrl.jwt.selectedRole` | the role chosen by the user (optional) |
 
 ---
 
@@ -77,14 +98,16 @@ Role:
 - Resolves domain and validates domain type (`JWT`).
 - Calls `JWTAuthenticationLogic.resolveAvailableRoles(...)` internally.
 - Chooses role with this strategy:
-  1. first role from ordered/normalized role list
-  2. otherwise `defaultRole`
-  3. otherwise authentication failure
+  1. If `xfmg.xopctrl.jwt.selectedRole` is set **and** the role is present in the JWT claims -> use selected role *(verified, cannot be spoofed)*
+  2. If `selectedRole` is set but **not** present in JWT claims -> authentication failure (reject)
+  3. If no `selectedRole` -> first role from ordered/normalized role list
+  4. otherwise `defaultRole`
+  5. otherwise authentication failure
 
 Public service surface:
 
-- `authenticate(...)` only
-- No public `resolveAvailableRoles(...)` operation is used in this architecture.
+- `authenticate(...)` ? used in the order-backed auth flow
+- `resolveAvailableRoles(...)` ? called by `ResolveAvailableRolesWithJWT` workflow to populate the role dropdown in the GUI
 
 ---
 
@@ -160,16 +183,33 @@ Invalid values for `authValidationMode` raise `IllegalArgumentException`.
 
 1. `/auth/externalUserLoginInformation`
    - Reads external identity from configured header/certificate.
-   - Returns only:
+   - Returns:
      - `username`
      - `userdisplayname`
-     - `externaldomains`
+     - `externaldomains` (legacy, for backward compatibility)
+     - `domains` ? list of `{ name, roles[] }` with available roles per domain, resolved via `ResolveAvailableRolesWithJWT` workflow
 
 2. `/auth/externalUserLogin`
    - Reads JWT token from configured header (for example `OIDC_access_token`).
+   - Accepts optional `selectedRole` field in the request body.
+   - If `selectedRole` is present, encodes it into the password as `selectedRole\0jwtToken`.
    - Calls `authorizeSession(...)`.
    - For JWT domains, `JWTUserAuthentication.authenticateUserInternally(...)` is used.
-   - Role is selected internally during auth processing (no user-side role choice).
+   - Role selection strategy (in `authenticate`):
+     - **With `selectedRole`**: verified against JWT claims ? used if valid, rejected if not present
+     - **Without `selectedRole`**: highest-priority extracted role, then `defaultRole` (original behavior, fully backward compatible)
+
+**Frontend flow (role dropdown):**
+
+```
+GET /auth/externalUserLoginInformation
+  -> Response: { domains: [{ name, roles[] }] }
+  -> GUI renders role dropdown (only if roles.length > 0)
+
+POST /auth/externalUserLogin
+  -> Body: { domain, force, path, selectedRole? }
+  -> selectedRole is verified server-side against JWT claims
+```
 
 ---
 
@@ -249,3 +289,5 @@ Recommended test matrix:
 - `JWT` is the safest default mode.
 - `HEADER` assumes a trusted reverse proxy (for example Apache with `mod_auth_openidc`) validates tokens and prevents header spoofing.
 - Role prioritization via `roleOrder` is applied after prefix/suffix normalization and is case-sensitive.
+- **`selectedRole` cannot be spoofed**: even if a client sends an manipulated `selectedRole`, it is always verified against the roles extracted from the (validated) JWT claims. A role not present in the token's claims causes an immediate authentication failure.
+- The `\0` encoding for `selectedRole` in the password field is an internal transport detail with no security implications, as the password is never persisted or exposed outside the authentication chain.

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -163,14 +163,13 @@ Operational note:
 
 Required:
 
-- `ordertype`
 - `trustedIssuers`
 - `intendedAudience`
+- `application` + `version` (runtime context for revision lookup)
 
 Optional:
 
-- `application` (together with `version`) or `workspace` for runtime context / revision lookup
-- `version` (together with `application`)
+- `ordertype` (default: `xact.http.jwt.auth.AuthenticateWithJWT`)
 - `roleClaimPath`
 - `defaultRole`
 - `rolePrefix`
@@ -178,6 +177,7 @@ Optional:
 - `roleOrder`
 - `jwksUri`
 - `rolesResolverOrdertype` (default: `xact.http.jwt.auth.ResolveAvailableRolesWithJWT`)
+- `preferredDomain`
 - `authValidationMode` (default: `JWT`)
 
 Invalid values for `authValidationMode` raise `IllegalArgumentException`.
@@ -192,7 +192,8 @@ Invalid values for `authValidationMode` raise `IllegalArgumentException`.
      - `username`
      - `userdisplayname`
      - `externaldomains` (legacy, for backward compatibility)
-     - `domains` - list of `{ name, roles[] }` with available roles per domain, resolved via `rolesResolverOrdertype` (or default `ResolveAvailableRolesWithJWT`)
+     - `domains` - list of `{ name, roles[] }` with available roles per domain, resolved via `rolesResolverOrdertype` (or default `ResolveAvailableRolesWithJWT`); role names are extracted from `xfmg.xopctrl.Role` objects returned by the workflow
+   - If any configured JWT domain has `preferredDomain` set, that domain is moved to the first position in the `domains` list.
 
 2. `/auth/externalUserLogin`
    - Reads JWT token from configured header (for example `OIDC_access_token`).
@@ -226,7 +227,6 @@ POST /auth/externalUserLogin
 ./xynafactory.sh setdomaintypespecificdata \
   -domainName JWT_DOMAIN \
   -domainTypeSpecificData \
-  ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
   application=JSONWebToken \
   version=1.0.5 \
   trustedIssuers=https://idp.example.com/realms/master \
@@ -236,13 +236,14 @@ POST /auth/externalUserLogin
   defaultRole=PortalUser
 ```
 
+`ordertype` is omitted here ? `xact.http.jwt.auth.AuthenticateWithJWT` is used by default.
+
 ### 3.2 Proxy-validated (`HEADER`)
 
 ```bash
 ./xynafactory.sh setdomaintypespecificdata \
   -domainName JWT_DOMAIN \
   -domainTypeSpecificData \
-  ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
   application=JSONWebToken \
   version=1.0.5 \
   trustedIssuers=https://idp.example.com/realms/master \
@@ -257,7 +258,6 @@ POST /auth/externalUserLogin
 ./xynafactory.sh setdomaintypespecificdata \
   -domainName JWT_DOMAIN \
   -domainTypeSpecificData \
-  ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
   application=JSONWebToken \
   version=1.0.5 \
   trustedIssuers=https://idp.example.com/realms/master \
@@ -269,6 +269,22 @@ POST /auth/externalUserLogin
 ```
 
 `roleOrder` is matched in configured order (case-sensitive) after normalization.
+
+### 3.4 With preferred domain
+
+```bash
+./xynafactory.sh setdomaintypespecificdata \
+  -domainName JWT_DOMAIN \
+  -domainTypeSpecificData \
+  application=JSONWebToken \
+  version=1.0.5 \
+  trustedIssuers=https://idp.example.com/realms/master \
+  intendedAudience=account \
+  preferredDomain=JWT_DOMAIN
+```
+
+`preferredDomain` causes the named domain to appear first in the login form's domain dropdown,
+regardless of the order in which domains are registered in Xyna.
 
 ---
 

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -71,7 +71,7 @@ Because the authentication infrastructure only provides a single `password` fiel
 
 ```
 password = "selectedRole\0jwtToken"   (if role was selected)
-password = "jwtToken"                 (if no role was selected ? backward compatible)
+password = "jwtToken"                 (if no role was selected - backward compatible)
 ```
 
 `\0` is safe here because JWT tokens are base64url-encoded and never contain this character.
@@ -106,8 +106,8 @@ Role:
 
 Public service surface:
 
-- `authenticate(...)` ? used in the order-backed auth flow
-- `resolveAvailableRoles(...)` ? called by `ResolveAvailableRolesWithJWT` workflow to populate the role dropdown in the GUI
+- `authenticate(...)` - used in the order-backed auth flow
+- `resolveAvailableRoles(...)` - called by `ResolveAvailableRolesWithJWT` workflow to populate the role dropdown in the GUI
 
 ---
 
@@ -187,7 +187,7 @@ Invalid values for `authValidationMode` raise `IllegalArgumentException`.
      - `username`
      - `userdisplayname`
      - `externaldomains` (legacy, for backward compatibility)
-     - `domains` ? list of `{ name, roles[] }` with available roles per domain, resolved via `ResolveAvailableRolesWithJWT` workflow
+     - `domains` - list of `{ name, roles[] }` with available roles per domain, resolved via `ResolveAvailableRolesWithJWT` workflow
 
 2. `/auth/externalUserLogin`
    - Reads JWT token from configured header (for example `OIDC_access_token`).
@@ -196,7 +196,7 @@ Invalid values for `authValidationMode` raise `IllegalArgumentException`.
    - Calls `authorizeSession(...)`.
    - For JWT domains, `JWTUserAuthentication.authenticateUserInternally(...)` is used.
    - Role selection strategy (in `authenticate`):
-     - **With `selectedRole`**: verified against JWT claims ? used if valid, rejected if not present
+     - **With `selectedRole`**: verified against JWT claims - used if valid, rejected if not present
      - **Without `selectedRole`**: highest-priority extracted role, then `defaultRole` (original behavior, fully backward compatible)
 
 **Frontend flow (role dropdown):**

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -223,7 +223,7 @@ POST /auth/externalUserLogin
   -domainTypeSpecificData \
   ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
   application=JSONWebToken \
-  version=1.0.4 \
+  version=1.0.5 \
   trustedIssuers=https://idp.example.com/realms/master \
   intendedAudience=account \
   authValidationMode=JWT \
@@ -239,7 +239,7 @@ POST /auth/externalUserLogin
   -domainTypeSpecificData \
   ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
   application=JSONWebToken \
-  version=1.0.4 \
+  version=1.0.5 \
   trustedIssuers=https://idp.example.com/realms/master \
   intendedAudience=account \
   authValidationMode=HEADER \
@@ -254,7 +254,7 @@ POST /auth/externalUserLogin
   -domainTypeSpecificData \
   ordertype=xact.http.jwt.auth.AuthenticateWithJWT \
   application=JSONWebToken \
-  version=1.0.4 \
+  version=1.0.5 \
   trustedIssuers=https://idp.example.com/realms/master \
   intendedAudience=account \
   authValidationMode=JWT \

--- a/design-docs/JWTDomainDesignDocument.md
+++ b/design-docs/JWTDomainDesignDocument.md
@@ -40,8 +40,8 @@ Configuration attributes:
 - `Optional<String> rolesResolverOrdertype` (optional, default: `xact.http.jwt.auth.ResolveAvailableRolesWithJWT`)
 - `AuthValidationMode authValidationMode` with values `HEADER|JWT` (default: `JWT`)
 
-`rolesResolverOrdertype` uses the same `RuntimeContext`/revision source as the JWT `ordertype`
-(from `application+version` or `workspace`).
+Both `associatedOrdertype` and `rolesResolverOrdertype` use the same `RuntimeContext`/revision source
+(from `application+version`).
 
 **Supported Authentication Modes:**
 
@@ -177,7 +177,6 @@ Optional:
 - `roleOrder`
 - `jwksUri`
 - `rolesResolverOrdertype` (default: `xact.http.jwt.auth.ResolveAvailableRolesWithJWT`)
-- `preferredDomain`
 - `authValidationMode` (default: `JWT`)
 
 Invalid values for `authValidationMode` raise `IllegalArgumentException`.
@@ -193,7 +192,7 @@ Invalid values for `authValidationMode` raise `IllegalArgumentException`.
      - `userdisplayname`
      - `externaldomains` (legacy, for backward compatibility)
      - `domains` - list of `{ name, roles[] }` with available roles per domain, resolved via `rolesResolverOrdertype` (or default `ResolveAvailableRolesWithJWT`); role names are extracted from `xfmg.xopctrl.Role` objects returned by the workflow
-   - If any configured JWT domain has `preferredDomain` set, that domain is moved to the first position in the `domains` list.
+   - Domain order is determined by the H5XdevFilter's `preferredDomain` parameter: if set, that domain appears first in the list.
 
 2. `/auth/externalUserLogin`
    - Reads JWT token from configured header (for example `OIDC_access_token`).
@@ -270,21 +269,24 @@ POST /auth/externalUserLogin
 
 `roleOrder` is matched in configured order (case-sensitive) after normalization.
 
-### 3.4 With preferred domain
+### 3.4 With H5XdevFilter preferred domain configuration
 
 ```bash
-./xynafactory.sh setdomaintypespecificdata \
-  -domainName JWT_DOMAIN \
-  -domainTypeSpecificData \
-  application=JSONWebToken \
-  version=1.0.5 \
-  trustedIssuers=https://idp.example.com/realms/master \
-  intendedAudience=account \
-  preferredDomain=JWT_DOMAIN
+./xynafactory.sh deployfilter \
+  -filterName H5XdevFilter \
+  -filterInstanceName H5XdevFilterinstance \
+  -triggerInstanceName HttpTrigger \
+  -applicationName GuiHttp \
+  -versionName 1.5.5 \
+  -configurationParameter \
+    externalAuthType=JSON_WEB_TOKEN \
+    externalAuthHeader=OIDC_access_token \
+    preferredDomain=JWT_DOMAIN
 ```
 
-`preferredDomain` causes the named domain to appear first in the login form's domain dropdown,
-regardless of the order in which domains are registered in Xyna.
+`preferredDomain` is a filter-level parameter (not domain-specific). It causes the named domain 
+to appear first in the login form's domain dropdown, regardless of registration order. 
+If not set or empty, the natural domain order is preserved.
 
 ---
 

--- a/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/JSONWebTokenAuthentication.xml
+++ b/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/JSONWebTokenAuthentication.xml
@@ -15,7 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
---><DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" IsAbstract="false" Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication" TypePath="xact.http.jwt.auth" Version="1.8">
+-->
+<DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" IsAbstract="false" Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication" TypePath="xact.http.jwt.auth" Version="1.8">
   <Meta>
     <IsServiceGroupOnly>true</IsServiceGroupOnly>
   </Meta>
@@ -34,6 +35,17 @@
       </Output>
       <SourceCode>
         <CodeSnippet Type="Java">return xact.http.jwt.auth.JSONWebTokenAuthenticationImpl.authenticate(correlatedXynaOrder, domainName2);</CodeSnippet>
+      </SourceCode>
+    </Operation>
+    <Operation IsStatic="true" Label="Resolve Available Roles" Name="resolveAvailableRoles" RequiresXynaOrder="true">
+      <Input>
+        <Data ID="3" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName3"/>
+      </Input>
+      <Output>
+        <Data ID="4" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text4"/>
+      </Output>
+      <SourceCode>
+        <CodeSnippet Type="Java">return xact.http.jwt.auth.JSONWebTokenAuthenticationImpl.resolveAvailableRoles(correlatedXynaOrder, domainName3);</CodeSnippet>
       </SourceCode>
     </Operation>
   </Service>

--- a/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/JSONWebTokenAuthentication.xml
+++ b/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/JSONWebTokenAuthentication.xml
@@ -42,7 +42,7 @@
         <Data ID="3" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName3"/>
       </Input>
       <Output>
-        <Data ID="4" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text4"/>
+        <Data ID="4" IsList="true" Label="Roles" ReferenceName="Role" ReferencePath="xfmg.xopctrl" VariableName="role4"/>
       </Output>
       <SourceCode>
         <CodeSnippet Type="Java">return xact.http.jwt.auth.JSONWebTokenAuthenticationImpl.resolveAvailableRoles(correlatedXynaOrder, domainName3);</CodeSnippet>

--- a/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/ResolveAvailableRolesWithJWT.xml
+++ b/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/ResolveAvailableRolesWithJWT.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+-->
+<Service xmlns="http://www.gip.com/xyna/xdev/xfractmod" Label="Resolve Available Roles With JWT" TypeName="ResolveAvailableRolesWithJWT" TypePath="xact.http.jwt.auth" Version="1.8">
+  <Operation ID="0" IsStatic="false" Label="Resolve Available Roles With JWT" Name="ResolveAvailableRolesWithJWT">
+    <Input>
+      <Data ID="18" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName18"/>
+    </Input>
+    <Output>
+      <Data ID="52" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text52"/>
+    </Output>
+    <ServiceReference ID="33" Label="JSON Web Token Authentication" ReferenceName="JSONWebTokenAuthentication.JSONWebTokenAuthentication" ReferencePath="xact.http.jwt.auth">
+      <Source RefID="32"/>
+      <Target RefID="32"/>
+    </ServiceReference>
+    <Function ID="32" Label="Resolve Available Roles">
+      <Source RefID="33"/>
+      <Source RefID="18"/>
+      <Target RefID="33"/>
+      <Target RefID="35"/>
+      <Invoke Operation="resolveAvailableRoles" ServiceID="33">
+        <Source RefID="18"/>
+      </Invoke>
+      <Receive ServiceID="33">
+        <Target RefID="35"/>
+      </Receive>
+    </Function>
+    <Data ID="35" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text35">
+      <Source RefID="32"/>
+    </Data>
+    <Assign ID="1">
+      <Source RefID="35"/>
+      <Target RefID="52"/>
+      <Copy>
+        <Source RefID="35"/>
+        <Target RefID="52"/>
+      </Copy>
+    </Assign>
+  </Operation>
+</Service>

--- a/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/ResolveAvailableRolesWithJWT.xml
+++ b/modules/xact/jsonwebtoken/XMOM/xact/http/jwt/auth/ResolveAvailableRolesWithJWT.xml
@@ -22,7 +22,7 @@
       <Data ID="18" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName18"/>
     </Input>
     <Output>
-      <Data ID="52" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text52"/>
+      <Data ID="52" IsList="true" Label="Roles" ReferenceName="Role" ReferencePath="xfmg.xopctrl" VariableName="role52"/>
     </Output>
     <ServiceReference ID="33" Label="JSON Web Token Authentication" ReferenceName="JSONWebTokenAuthentication.JSONWebTokenAuthentication" ReferencePath="xact.http.jwt.auth">
       <Source RefID="32"/>
@@ -40,7 +40,7 @@
         <Target RefID="35"/>
       </Receive>
     </Function>
-    <Data ID="35" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text35">
+    <Data ID="35" IsList="true" Label="Roles" ReferenceName="Role" ReferencePath="xfmg.xopctrl" VariableName="role35">
       <Source RefID="32"/>
     </Data>
     <Assign ID="1">

--- a/modules/xact/jsonwebtoken/application.xml
+++ b/modules/xact/jsonwebtoken/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="JSONWebToken" factoryVersion="" versionName="1.0.4" xmlVersion="1.1">
+<Application applicationName="JSONWebToken" factoryVersion="" versionName="1.0.5" xmlVersion="1.1">
     <ApplicationInfo>
         <Description Lang="DE">Tools um JSON Web Tokens zu erzeugen, zu parsen und zu bearbeiten</Description>
         <Description Lang="EN">Tools for creating, parsing and working with JSON Web Tokens</Description>

--- a/modules/xact/jsonwebtoken/application.xml
+++ b/modules/xact/jsonwebtoken/application.xml
@@ -36,6 +36,10 @@
             <DestinationKey>xact.http.jwt.auth.AuthenticateWithJWT</DestinationKey>
             <OrderContextMapping>true</OrderContextMapping>
         </Ordertype>
+        <Ordertype implicitDependency="true">
+            <DestinationKey>xact.http.jwt.auth.ResolveAvailableRolesWithJWT</DestinationKey>
+            <OrderContextMapping>true</OrderContextMapping>
+        </Ordertype>
     </Ordertypes>
     <SharedLibs>
         <SharedLib implicitDependency="false">
@@ -73,6 +77,10 @@
         </XMOMEntry>
         <XMOMEntry implicitDependency="false">
             <FqName>xact.http.jwt.auth.AuthenticateWithJWT</FqName>
+            <Type>WORKFLOW</Type>
+        </XMOMEntry>
+        <XMOMEntry implicitDependency="false">
+            <FqName>xact.http.jwt.auth.ResolveAvailableRolesWithJWT</FqName>
             <Type>WORKFLOW</Type>
         </XMOMEntry>
         <XMOMEntry implicitDependency="false">

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -39,7 +39,7 @@ import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
 import com.gip.xyna.xprc.XynaOrderServerExtension;
 import com.gip.xyna.xprc.xpce.OrderContext;
 
-import base.Text;
+import xfmg.xopctrl.Role;
 import xact.http.jwt.auth.JSONWebTokenAuthenticationServiceOperation;
 
 
@@ -160,7 +160,7 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
 
 
   @Override
-  public List<? extends Text> resolveAvailableRoles(XynaOrderServerExtension arg0, DomainName arg1) {
+  public List<? extends Role> resolveAvailableRoles(XynaOrderServerExtension arg0, DomainName arg1) {
     OrderContext ctx = arg0.getOrderContext();
     Domain domain = resolveDomain(arg1 == null ? null : arg1.getName());
     if (domain == null || domain.getDomainTypeAsEnum() != DomainType.JWT || !(domain.getDomainSpecificData() instanceof JWTDomainSpecificData)) {
@@ -178,13 +178,15 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
       if (roles == null || roles.isEmpty()) {
         return Collections.emptyList();
       }
-      List<Text> textRoles = new ArrayList<>(roles.size());
-      for (String role : roles) {
-        if (role != null) {
-          textRoles.add(new Text(role));
+      List<Role> roleObjects = new ArrayList<>(roles.size());
+      for (String roleName : roles) {
+        if (roleName != null) {
+          Role r = new Role();
+          r.setName(roleName);
+          roleObjects.add(r);
         }
       }
-      return textRoles;
+      return roleObjects;
     } catch (XFMG_UserAuthenticationFailedException e) {
       return Collections.emptyList();
     }

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -47,6 +47,7 @@ import xact.http.jwt.auth.JSONWebTokenAuthenticationServiceOperation;
 public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedDeploymentTask, JSONWebTokenAuthenticationServiceOperation {
 
   private static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
+  private static final String ORDER_CONTEXT_KEY_SELECTED_ROLE = "xfmg.xopctrl.jwt.selectedRole";
   private static final Logger logger = CentralFactoryLogging.getLogger(JSONWebTokenAuthenticationServiceOperationImpl.class);
 
 
@@ -107,9 +108,29 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
       // get roles from token claim, with DomainSpecificData do JWTAuthenticationLogic.resolveAvailableRoles()
       JWTDomainSpecificData dsd = (JWTDomainSpecificData) domain.getDomainSpecificData();
       List<String> roles = JWTAuthenticationLogic.resolveAvailableRoles(dsd, token);
+
+      // check if caller requested a specific role (from GUI dropdown)
+      Serializable selectedRoleValue = ctx.get(ORDER_CONTEXT_KEY_SELECTED_ROLE);
+      String requestedRole = selectedRoleValue instanceof String ? ((String) selectedRoleValue).trim() : null;
+
       String role = null;
       String roleSource = null;
-      if (roles != null && !roles.isEmpty()) {
+
+      if (requestedRole != null && !requestedRole.isEmpty()) {
+        // verify requested role is actually present in JWT claims ? prevents spoofing
+        if (roles != null && roles.contains(requestedRole)) {
+          role = requestedRole;
+          roleSource = "selectedRole (verified)";
+        } else {
+          // role was requested but not found in claims ? reject
+          logger.warn(
+              "authenticate: requested selectedRole '" + requestedRole + "' not present in JWT claims " + roles + " ? login rejected");
+          AuthenticationResult result = new AuthenticationResult();
+          result.setSuccess(false);
+          return result;
+        }
+      } else if (roles != null && !roles.isEmpty()) {
+        // no selectedRole -> use highest-priority extracted role (original behavior backward compatibility old gui)
         role = roles.get(0);
         roleSource = "extractedRoles";
       } else {

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -20,6 +20,8 @@ package xact.http.jwt.auth.impl;
 
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -37,6 +39,7 @@ import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
 import com.gip.xyna.xprc.XynaOrderServerExtension;
 import com.gip.xyna.xprc.xpce.OrderContext;
 
+import base.Text;
 import xact.http.jwt.auth.JSONWebTokenAuthenticationServiceOperation;
 
 
@@ -131,6 +134,38 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
       AuthenticationResult result = new AuthenticationResult();
       result.setSuccess(false);
       return result;
+    }
+  }
+
+
+  @Override
+  public List<? extends Text> resolveAvailableRoles(XynaOrderServerExtension arg0, DomainName arg1) {
+    OrderContext ctx = arg0.getOrderContext();
+    Domain domain = resolveDomain(arg1 == null ? null : arg1.getName());
+    if (domain == null || domain.getDomainTypeAsEnum() != DomainType.JWT || !(domain.getDomainSpecificData() instanceof JWTDomainSpecificData)) {
+      return Collections.emptyList();
+    }
+    try {
+      Serializable tokenValue = ctx.get(ORDER_CONTEXT_KEY_JWT_TOKEN);
+      String token = tokenValue instanceof String ? (String) tokenValue : null;
+      if (token == null || token.isEmpty()) {
+        return Collections.emptyList();
+      }
+
+      JWTDomainSpecificData dsd = (JWTDomainSpecificData) domain.getDomainSpecificData();
+      List<String> roles = JWTAuthenticationLogic.resolveAvailableRoles(dsd, token);
+      if (roles == null || roles.isEmpty()) {
+        return Collections.emptyList();
+      }
+      List<Text> textRoles = new ArrayList<>(roles.size());
+      for (String role : roles) {
+        if (role != null) {
+          textRoles.add(new Text(role));
+        }
+      }
+      return textRoles;
+    } catch (XFMG_UserAuthenticationFailedException e) {
+      return Collections.emptyList();
     }
   }
 

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -117,20 +117,20 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
       String roleSource = null;
 
       if (requestedRole != null && !requestedRole.isEmpty()) {
-        // verify requested role is actually present in JWT claims ? prevents spoofing
+        // verify requested role is actually present in JWT claims - prevents spoofing
         if (roles != null && roles.contains(requestedRole)) {
           role = requestedRole;
           roleSource = "selectedRole (verified)";
         } else {
-          // role was requested but not found in claims ? reject
+          // role was requested but not found in claims -> reject
           logger.warn(
-              "authenticate: requested selectedRole '" + requestedRole + "' not present in JWT claims " + roles + " ? login rejected");
+              "authenticate: requested selectedRole '" + requestedRole + "' not present in JWT claims " + roles + " - login rejected");
           AuthenticationResult result = new AuthenticationResult();
           result.setSuccess(false);
           return result;
         }
       } else if (roles != null && !roles.isEmpty()) {
-        // no selectedRole -> use highest-priority extracted role (original behavior backward compatibility old gui)
+        // no selectedRole -> use highest-priority extracted role
         role = roles.get(0);
         roleSource = "extractedRoles";
       } else {

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/src/xact/http/jwt/auth/impl/JSONWebTokenAuthenticationServiceOperationImpl.java
@@ -90,9 +90,7 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
     OrderContext ctx = arg0.getOrderContext();
     Domain domain = resolveDomain(arg1 == null ? null : arg1.getName());
     if (domain == null || domain.getDomainTypeAsEnum() != DomainType.JWT || !(domain.getDomainSpecificData() instanceof JWTDomainSpecificData)) {
-      AuthenticationResult result = new AuthenticationResult();
-      result.setSuccess(false);
-      return result;
+      return new AuthenticationResult.Builder().success(false).instance();
     }
 
     // get token from OrderContext and check
@@ -100,9 +98,7 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
       Serializable tokenValue = ctx.get(ORDER_CONTEXT_KEY_JWT_TOKEN);
       String token = tokenValue instanceof String ? (String) tokenValue : null;
       if (token == null || token.isEmpty()) {
-        AuthenticationResult result = new AuthenticationResult();
-        result.setSuccess(false);
-        return result;
+        return new AuthenticationResult.Builder().success(false).instance();
       }
 
       // get roles from token claim, with DomainSpecificData do JWTAuthenticationLogic.resolveAvailableRoles()
@@ -125,9 +121,7 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
           // role was requested but not found in claims -> reject
           logger.warn(
               "authenticate: requested selectedRole '" + requestedRole + "' not present in JWT claims " + roles + " - login rejected");
-          AuthenticationResult result = new AuthenticationResult();
-          result.setSuccess(false);
-          return result;
+          return new AuthenticationResult.Builder().success(false).instance();
         }
       } else if (roles != null && !roles.isEmpty()) {
         // no selectedRole -> use highest-priority extracted role
@@ -138,23 +132,16 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
         roleSource = "defaultRole";
       }
       if (role == null || role.trim().isEmpty()) {
-        AuthenticationResult result = new AuthenticationResult();
-        result.setSuccess(false);
-        return result;
+        return new AuthenticationResult.Builder().success(false).instance();
       }
 
       if (logger.isDebugEnabled()) {
         logger.debug("authenticate: using role '" + role.trim() + "' for login (source=" + roleSource + ")");
       }
 
-      AuthenticationResult result = new AuthenticationResult();
-      result.setSuccess(true);
-      result.setRole(role.trim());
-      return result;
+      return new AuthenticationResult.Builder().success(true).role(role.trim()).instance();
     } catch (XFMG_UserAuthenticationFailedException e) {
-      AuthenticationResult result = new AuthenticationResult();
-      result.setSuccess(false);
-      return result;
+      return new AuthenticationResult.Builder().success(false).instance();
     }
   }
 
@@ -182,7 +169,7 @@ public class JSONWebTokenAuthenticationServiceOperationImpl implements ExtendedD
       for (String roleName : roles) {
         if (roleName != null) {
           Role r = new Role();
-          r.setName(roleName);
+          r.unversionedSetName(roleName);
           roleObjects.add(r);
         }
       }

--- a/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/xmldefinition/JSONWebTokenAuthentication.xml
+++ b/modules/xact/jsonwebtoken/mdmimpl/JSONWebTokenAuthenticationImpl/xmldefinition/JSONWebTokenAuthentication.xml
@@ -15,7 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
---><DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" IsAbstract="false" Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication" TypePath="xact.http.jwt.auth" Version="1.8">
+-->
+<DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" IsAbstract="false" Label="JSON Web Token Authentication" TypeName="JSONWebTokenAuthentication" TypePath="xact.http.jwt.auth" Version="1.8">
   <Meta>
     <IsServiceGroupOnly>true</IsServiceGroupOnly>
   </Meta>
@@ -30,6 +31,17 @@
       </Output>
       <SourceCode>
         <CodeSnippet Type="Java">return JSONWebTokenAuthenticationImpl.authenticate(domainName2);</CodeSnippet>
+      </SourceCode>
+    </Operation>
+    <Operation IsStatic="true" Label="Resolve Available Roles" Name="resolveAvailableRoles">
+      <Input>
+        <Data ID="3" Label="Domain Name" ReferenceName="DomainName" ReferencePath="xfmg.xopctrl" VariableName="domainName3"/>
+      </Input>
+      <Output>
+        <Data ID="4" IsList="true" Label="Roles" ReferenceName="Text" ReferencePath="base" VariableName="text4"/>
+      </Output>
+      <SourceCode>
+        <CodeSnippet Type="Java">return JSONWebTokenAuthenticationImpl.resolveAvailableRoles(domainName3);</CodeSnippet>
       </SourceCode>
     </Operation>
   </Service>

--- a/modules/xdev/yang/application.xml
+++ b/modules/xdev/yang/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.6</VersionName>
+        <VersionName>1.5.7</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>YangBase</ApplicationName>

--- a/modules/xdev/yang/application.xml
+++ b/modules/xdev/yang/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.5</VersionName>
+        <VersionName>1.5.6</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>YangBase</ApplicationName>

--- a/modules/xmcp/gitIntegration/application.xml
+++ b/modules/xmcp/gitIntegration/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.5</VersionName>
+        <VersionName>1.5.6</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xmcp/gitIntegration/application.xml
+++ b/modules/xmcp/gitIntegration/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.6</VersionName>
+        <VersionName>1.5.7</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xmcp/guihttp/XMOM/xmcp/auth/ExternalUserLoginRequest.xml
+++ b/modules/xmcp/guihttp/XMOM/xmcp/auth/ExternalUserLoginRequest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2026 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
---><DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" Label="External User Login Request" TypeName="ExternalUserLoginRequest" TypePath="xmcp.auth" Version="1.8">
+-->
+<DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" Label="External User Login Request" TypeName="ExternalUserLoginRequest" TypePath="xmcp.auth" Version="1.8">
   <Meta>
     <IsServiceGroupOnly>false</IsServiceGroupOnly>
   </Meta>
@@ -30,6 +31,11 @@
     </Meta>
   </Data>
   <Data Label="Path" VariableName="path">
+    <Meta>
+      <Type>String</Type>
+    </Meta>
+  </Data>
+  <Data Label="Selected Role" VariableName="selectedRole">
     <Meta>
       <Type>String</Type>
     </Meta>

--- a/modules/xmcp/guihttp/application.xml
+++ b/modules/xmcp/guihttp/application.xml
@@ -17,7 +17,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <!--                                               ################# Version auch in blackedition_lib.sh updaten ########### -->
-<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.5.6" xmlVersion="1.1">
+<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.5.7" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">Interne Funktionalität zum Interagieren des Xyna Fractal Modellers mit dem Xyna Factory Server</Description>
     <Description Lang="EN">Internal functionality for interaction of the Xyna Fractal Modeller with the Xyna Factory Server</Description>

--- a/modules/xmcp/guihttp/application.xml
+++ b/modules/xmcp/guihttp/application.xml
@@ -17,7 +17,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
 <!--                                               ################# Version auch in blackedition_lib.sh updaten ########### -->
-<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.5.5" xmlVersion="1.1">
+<Application applicationName="GuiHttp" comment="" factoryVersion="" versionName="1.5.6" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">Interne Funktionalität zum Interagieren des Xyna Fractal Modellers mit dem Xyna Factory Server</Description>
     <Description Lang="EN">Internal functionality for interaction of the Xyna Fractal Modeller with the Xyna Factory Server</Description>

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/ConfigurableFilterAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/ConfigurableFilterAction.java
@@ -1,0 +1,35 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+package com.gip.xyna.xact.filter;
+
+import com.gip.xyna.utils.exceptions.XynaException;
+import com.gip.xyna.xact.filter.FilterAction.FilterActionInstance;
+import com.gip.xyna.xact.trigger.HTTPTriggerConnection;
+
+/**
+ * Marker interface for FilterActions that are aware of the filter configuration.
+ * H5XdevFilter calls actWithConfig() instead of act() for actions implementing this interface.
+ * All other actions remain untouched.
+ */
+public interface ConfigurableFilterAction extends FilterAction {
+
+  FilterActionInstance actWithConfig(URLPath url, HTTPTriggerConnection tc, H5XdevFilterParameter config)
+      throws XynaException;
+
+}
+

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilter.java
@@ -28,6 +28,7 @@ import com.gip.xyna.CentralFactoryLogging;
 import com.gip.xyna.XynaFactory;
 import com.gip.xyna.utils.exceptions.XynaException;
 import com.gip.xyna.xact.filter.CallStatistics.StatisticsEntry;
+import com.gip.xyna.xact.filter.ConfigurableFilterAction;
 import com.gip.xyna.xact.filter.FilterAction.FilterActionInstance;
 import com.gip.xyna.xact.filter.actions.*;
 import com.gip.xyna.xact.filter.actions.auth.ChangePasswordAction;
@@ -484,10 +485,6 @@ public class H5XdevFilter extends ConnectionFilter<HTTPTriggerConnection> {
       }
 
       config = (H5XdevFilterParameter)params;
-
-      ExternalUserLoginAction.setExternalAuthType(config.getExternalAuthType());
-      ExternalUserLoginAction.setAuthTokenHeaderName(config.getExternalAuthHeader());
-      ExternalUserLoginInformationAction.setPreferredDomainName(config.getPreferredDomain());
     }
 
     return createXynaOrder(tc);
@@ -530,7 +527,11 @@ public class H5XdevFilter extends ConnectionFilter<HTTPTriggerConnection> {
     try {
       for (FilterAction fa : allFilterActions) {
         if (matchAction(fa, url, tc.getMethodEnum())) {
-          filterActionInstance = fa.act(url, tc);
+          if (fa instanceof ConfigurableFilterAction) {
+            filterActionInstance = ((ConfigurableFilterAction) fa).actWithConfig(url, tc, config);
+          } else {
+            filterActionInstance = fa.act(url, tc);
+          }
           if (filterActionInstance == null) {
             continue;
           }

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilter.java
@@ -487,6 +487,7 @@ public class H5XdevFilter extends ConnectionFilter<HTTPTriggerConnection> {
 
       ExternalUserLoginAction.setExternalAuthType(config.getExternalAuthType());
       ExternalUserLoginAction.setAuthTokenHeaderName(config.getExternalAuthHeader());
+      ExternalUserLoginInformationAction.setPreferredDomainName(config.getPreferredDomain());
     }
 
     return createXynaOrder(tc);

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
@@ -19,6 +19,7 @@ package com.gip.xyna.xact.filter;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import com.gip.xyna.utils.misc.Documentation;
 import com.gip.xyna.utils.misc.StringParameter;
 import com.gip.xyna.xact.exceptions.XACT_InvalidFilterConfigurationParameterValueException;
@@ -94,6 +95,25 @@ public class H5XdevFilterParameter extends FilterConfigurationParameter {
     param.authHeader = AUTH_HEADER.getDefaultValue();
     param.preferredDomain = PREFERRED_DOMAIN.getDefaultValue();
     return param;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof H5XdevFilterParameter)) {
+      return false;
+    }
+    H5XdevFilterParameter that = (H5XdevFilterParameter) obj;
+    return authType == that.authType
+        && Objects.equals(authHeader, that.authHeader)
+        && Objects.equals(preferredDomain, that.preferredDomain);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(authType, authHeader, preferredDomain);
   }
 
   @Override

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
@@ -84,6 +84,18 @@ public class H5XdevFilterParameter extends FilterConfigurationParameter {
     return preferredDomain;
   }
 
+  /**
+   * Creates a config instance populated with all parameter default values.
+   * Used as fallback when act() is called without a config (backward compatibility).
+   */
+  public static H5XdevFilterParameter createDefaultConfig() {
+    H5XdevFilterParameter param = new H5XdevFilterParameter();
+    param.authType = AUTH_TYPE.getDefaultValue();
+    param.authHeader = AUTH_HEADER.getDefaultValue();
+    param.preferredDomain = PREFERRED_DOMAIN.getDefaultValue();
+    return param;
+  }
+
   @Override
   public String toString() {
     return "H5XdevFilterParameter{" +

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/H5XdevFilterParameter.java
@@ -44,11 +44,19 @@ public class H5XdevFilterParameter extends FilterConfigurationParameter {
                   .build())
           .optional().defaultValue("SSL_CLIENT_CERT").build();
 
+  public static final StringParameter<String> PREFERRED_DOMAIN = StringParameter.typeString("preferredDomain")
+          .documentation(Documentation
+                  .de("Bevorzugte Domain, die bei der Login-Auswahl zuerst herangezogen wird.")
+                  .en("Preferred domain first processed in the login selection.")
+                  .build())
+          .optional().defaultValue("").build();
+
   protected static final List<StringParameter<?>> ALL_PARAMETERS = 
-    StringParameter.asList( AUTH_TYPE, AUTH_HEADER );
+    StringParameter.asList( AUTH_TYPE, AUTH_HEADER, PREFERRED_DOMAIN );
 
   private ExternalAuthType authType;
   private String authHeader;
+  private String preferredDomain;
 
   @Override
   public List<StringParameter<?>> getAllStringParameters() {
@@ -60,6 +68,7 @@ public class H5XdevFilterParameter extends FilterConfigurationParameter {
     H5XdevFilterParameter param = new H5XdevFilterParameter();
     param.authType = AUTH_TYPE.getFromMap(paramMap);
     param.authHeader = AUTH_HEADER.getFromMap(paramMap);
+    param.preferredDomain = PREFERRED_DOMAIN.getFromMap(paramMap);
     return param;
   }
 
@@ -71,11 +80,16 @@ public class H5XdevFilterParameter extends FilterConfigurationParameter {
     return authHeader;
   }
 
+  public String getPreferredDomain() {
+    return preferredDomain;
+  }
+
   @Override
   public String toString() {
     return "H5XdevFilterParameter{" +
             "authType=" + authType +
             ", authHeader='" + authHeader + '\'' +
+            ", preferredDomain='" + preferredDomain + '\'' +
             '}';
 }
 }

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
@@ -109,7 +109,6 @@ public class ExternalUserLoginAction implements ConfigurableFilterAction {
 
   /**
    * Config-aware entry point called by H5XdevFilter.
-   * Casts the config to H5XdevFilterParameter and delegates to the actual logic.
    */
   @Override
   public FilterActionInstance actWithConfig(URLPath url, HTTPTriggerConnection tc, H5XdevFilterParameter config) throws XynaException {

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
@@ -29,11 +29,14 @@ import com.gip.xyna.XynaFactory;
 import com.gip.xyna.utils.collections.Optional;
 import com.gip.xyna.utils.collections.Pair;
 import com.gip.xyna.utils.exceptions.XynaException;
+import com.gip.xyna.xact.filter.ConfigurableFilterAction;
 import com.gip.xyna.xact.filter.FilterAction;
+import com.gip.xyna.xact.filter.H5XdevFilterParameter;
 import com.gip.xyna.xact.filter.HTMLBuilder.HTMLPart;
 import com.gip.xyna.xact.filter.JsonFilterActionInstance;
 import com.gip.xyna.xact.filter.URLPath;
 import com.gip.xyna.xact.filter.actions.auth.utils.AuthUtils;
+import com.gip.xyna.xact.filter.H5XdevFilterParameter;
 import com.gip.xyna.xact.filter.session.XMOMGui;
 import com.gip.xyna.xact.filter.session.XMOMGuiReply.Status;
 import com.gip.xyna.xact.filter.util.Utils;
@@ -62,7 +65,7 @@ import xmcp.auth.ExternalUserLoginRequest;
  * so wie beim login, nur dass die sessionerzeugung über die externe domain passiert
  *
  */
-public class ExternalUserLoginAction implements FilterAction {
+public class ExternalUserLoginAction implements ConfigurableFilterAction {
 
   private static final Logger logger = CentralFactoryLogging.getLogger(ExternalUserLoginAction.class);
 
@@ -81,9 +84,6 @@ public class ExternalUserLoginAction implements FilterAction {
 
 
   private XMOMGui xmomgui;
-  private static String headerName = SSL_CLIENT_CERT;
-  private static ExternalAuthType loginType = ExternalAuthType.CLIENT_CERT;
-
 
 
   public static enum ExternalAuthType {
@@ -93,16 +93,6 @@ public class ExternalUserLoginAction implements FilterAction {
 
   public ExternalUserLoginAction(XMOMGui xmomgui) {
     this.xmomgui = xmomgui;
-  }
-
-
-  public static void setExternalAuthType(ExternalAuthType type) {
-    loginType = type;
-  }
-
-
-  public static void setAuthTokenHeaderName(String value) {
-    headerName = value.toLowerCase();
   }
 
 
@@ -117,8 +107,80 @@ public class ExternalUserLoginAction implements FilterAction {
   }
 
 
-  public static Pair<Boolean, ExternalUserInfo> getExternalUserInfoOrFail(JsonFilterActionInstance jfai, HTTPTriggerConnection tc)
+  /**
+   * Config-aware entry point called by H5XdevFilter.
+   * Casts the config to H5XdevFilterParameter and delegates to the actual logic.
+   */
+  @Override
+  public FilterActionInstance actWithConfig(URLPath url, HTTPTriggerConnection tc, H5XdevFilterParameter config) throws XynaException {
+    return actInternal(url, tc, config);
+  }
+
+
+  /**
+   * Legacy entry point - called when no config is passed (backward compatibility).
+   * Uses parameter defaults.
+   */
+  @Override
+  public FilterActionInstance act(URLPath url, HTTPTriggerConnection tc) throws XynaException {
+    return actInternal(url, tc, H5XdevFilterParameter.createDefaultConfig());
+  }
+
+
+  private FilterActionInstance actInternal(URLPath url, HTTPTriggerConnection tc, H5XdevFilterParameter config) throws XynaException {
+    JsonFilterActionInstance jfai = new JsonFilterActionInstance();
+    String payload = AuthUtils.insertFqnIfNeeded(tc.getPayload(), "xmcp.auth.ExternalUserLoginRequest");
+    Pair<Boolean, ExternalUserInfo> p = getExternalUserInfoOrFail(jfai, tc, config);
+    if (p.getFirst()) {
+      return jfai;
+    }
+    ExternalUserInfo eui = p.getSecond();
+    if (eui == null) {
+      AuthUtils.replyError(tc, jfai, Status.unauthorized, noUserInfoException);
+      return jfai;
+    }
+
+    // parse request
+    ExternalUserLoginRequest request = (ExternalUserLoginRequest) Utils.convertJsonToGeneralXynaObjectUsingGuiHttp(payload);
+
+    // create session
+    boolean force = request.getForce() != null ? request.getForce() : true;
+    String domainName = request.getDomain();
+    SessionCredentials creds = XynaFactory.getInstance().getFactoryManagement()
+        .createSession(new XynaUserCredentials(eui.externalUserName, ""), Optional.<String> empty(), force);
+
+    // encode optional selectedRole into password: "selectedRole\0jwtToken"
+    // \0 is safe as JWT tokens are base64url-encoded and never contain this character
+    String selectedRole = request.getSelectedRole();
+    if (logger.isDebugEnabled()) {
+      logger.debug("externalUserLogin: selectedRole from request='" + selectedRole + "'");
+    }
+
+    String externalUserPasswordWithRole =
+        (selectedRole != null && !selectedRole.isEmpty()) ? selectedRole + "\0" + eui.externalUserPassword : eui.externalUserPassword;
+
+    // authorize session through external domain
+    try {
+      if (!new RMIChannelImpl().authorizeSession(new XynaUserCredentials(eui.externalUserName, externalUserPasswordWithRole), domainName,
+                                                 new XynaPlainSessionCredentials(creds.getSessionId(), creds.getToken()))) {
+        return error(creds, tc, jfai);
+      }
+    } catch (RemoteException e) {
+      if (e.getMessage().contains("XYNA-04049")) {
+        return error(creds, tc, jfai, new XFMG_DuplicateSessionException(eui.externalUserName));
+      } else {
+        return error(creds, tc, jfai, e);
+      }
+    }
+
+    return LoginAction.createLoginResponse(jfai, tc, creds, request.getPath(), xmomgui);
+  }
+
+
+  static Pair<Boolean, ExternalUserInfo> getExternalUserInfoOrFail(JsonFilterActionInstance jfai, HTTPTriggerConnection tc, H5XdevFilterParameter config)
       throws XynaException {
+    String headerName = config.getExternalAuthHeader().toLowerCase();
+    ExternalAuthType loginType = config.getExternalAuthType();
     String header = tc.getHeader().getProperty(headerName);
     try {
       if (logger.isDebugEnabled()) {
@@ -146,57 +208,6 @@ public class ExternalUserLoginAction implements FilterAction {
       AuthUtils.replyError(tc, jfai, Status.badRequest, ex);
       return Pair.of(true, null);
     }
-  }
-
-
-  @Override
-  public FilterActionInstance act(URLPath url, HTTPTriggerConnection tc) throws XynaException {
-    JsonFilterActionInstance jfai = new JsonFilterActionInstance();
-    String payload = AuthUtils.insertFqnIfNeeded(tc.getPayload(), "xmcp.auth.ExternalUserLoginRequest");
-    Pair<Boolean, ExternalUserInfo> p = getExternalUserInfoOrFail(jfai, tc);
-    if (p.getFirst()) {
-      return jfai;
-    }
-    ExternalUserInfo eui = p.getSecond();
-    if (eui == null) {
-      AuthUtils.replyError(tc, jfai, Status.unauthorized, noUserInfoException);
-      return jfai;
-    }
-
-    //parsing
-    ExternalUserLoginRequest request = (ExternalUserLoginRequest) Utils.convertJsonToGeneralXynaObjectUsingGuiHttp(payload);
-
-    //session erzeugen
-    boolean force = request.getForce() != null ? request.getForce() : true;
-    String domainName = request.getDomain();
-    SessionCredentials creds = XynaFactory.getInstance().getFactoryManagement()
-        .createSession(new XynaUserCredentials(eui.externalUserName, ""), Optional.<String> empty(), force);
-
-    // encode optional selectedRole into password: "selectedRole\0jwtToken"
-    // \0 is safe as JWT tokens are base64url-encoded and never contain this character
-    String selectedRole = request.getSelectedRole();
-    if (logger.isDebugEnabled()) {
-      logger.debug("externalUserLogin: selectedRole from request='" + selectedRole + "'");
-    }
-
-    String externalUserPasswordWithRole =
-        (selectedRole != null && !selectedRole.isEmpty()) ? selectedRole + "\0" + eui.externalUserPassword : eui.externalUserPassword;
-
-    //session fremd-authorisieren
-    try {
-      if (!new RMIChannelImpl().authorizeSession(new XynaUserCredentials(eui.externalUserName, externalUserPasswordWithRole), domainName,
-                                                 new XynaPlainSessionCredentials(creds.getSessionId(), creds.getToken()))) {
-        return error(creds, tc, jfai);
-      }
-    } catch (RemoteException e) {
-      if (e.getMessage().contains("XYNA-04049")) {
-        return error(creds, tc, jfai, new XFMG_DuplicateSessionException(eui.externalUserName));
-      } else {
-        return error(creds, tc, jfai, e);
-      }
-    }
-
-    return LoginAction.createLoginResponse(jfai, tc, creds, request.getPath(), xmomgui);
   }
 
 

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginAction.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2026 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,10 +57,10 @@ import xmcp.auth.ExternalUserLoginRequest;
  * "force":"true"
  * "domain":"<domainname>"
  * }
- * 
+ *
  * antwort:
  * so wie beim login, nur dass die sessionerzeugung über die externe domain passiert
- * 
+ *
  */
 public class ExternalUserLoginAction implements FilterAction {
 
@@ -71,31 +71,40 @@ public class ExternalUserLoginAction implements FilterAction {
   private static final Exception noUserInfoException = new Exception("No user info provided");
   private static final Exception notAuthorizedException = new Exception("Session could not be authorized.");
   private static final Exception internalServerError = new Exception("Internal Server Error");
+
+
   static {
     noUserInfoException.setStackTrace(new StackTraceElement[0]);
     notAuthorizedException.setStackTrace(new StackTraceElement[0]);
     internalServerError.setStackTrace(new StackTraceElement[0]);
   }
-  
+
+
   private XMOMGui xmomgui;
   private static String headerName = SSL_CLIENT_CERT;
   private static ExternalAuthType loginType = ExternalAuthType.CLIENT_CERT;
+
+
 
   public static enum ExternalAuthType {
     CLIENT_CERT, JSON_WEB_TOKEN;
   }
 
+
   public ExternalUserLoginAction(XMOMGui xmomgui) {
     this.xmomgui = xmomgui;
   }
+
 
   public static void setExternalAuthType(ExternalAuthType type) {
     loginType = type;
   }
 
+
   public static void setAuthTokenHeaderName(String value) {
     headerName = value.toLowerCase();
   }
+
 
   @Override
   public boolean match(URLPath url, Method method) {
@@ -106,7 +115,6 @@ public class ExternalUserLoginAction implements FilterAction {
   public String getTitle() {
     return "External User Login";
   }
-
 
 
   public static Pair<Boolean, ExternalUserInfo> getExternalUserInfoOrFail(JsonFilterActionInstance jfai, HTTPTriggerConnection tc)
@@ -164,9 +172,19 @@ public class ExternalUserLoginAction implements FilterAction {
     SessionCredentials creds = XynaFactory.getInstance().getFactoryManagement()
         .createSession(new XynaUserCredentials(eui.externalUserName, ""), Optional.<String> empty(), force);
 
+    // encode optional selectedRole into password: "selectedRole\0jwtToken"
+    // \0 is safe as JWT tokens are base64url-encoded and never contain this character
+    String selectedRole = request.getSelectedRole();
+    if (logger.isDebugEnabled()) {
+      logger.debug("externalUserLogin: selectedRole from request='" + selectedRole + "'");
+    }
+
+    String externalUserPasswordWithRole =
+        (selectedRole != null && !selectedRole.isEmpty()) ? selectedRole + "\0" + eui.externalUserPassword : eui.externalUserPassword;
+
     //session fremd-authorisieren
     try {
-      if (!new RMIChannelImpl().authorizeSession(new XynaUserCredentials(eui.externalUserName, eui.externalUserPassword), domainName,
+      if (!new RMIChannelImpl().authorizeSession(new XynaUserCredentials(eui.externalUserName, externalUserPasswordWithRole), domainName,
                                                  new XynaPlainSessionCredentials(creds.getSessionId(), creds.getToken()))) {
         return error(creds, tc, jfai);
       }
@@ -187,7 +205,7 @@ public class ExternalUserLoginAction implements FilterAction {
     return error(creds, tc, jfai, notAuthorizedException);
   }
 
-  
+
   private FilterActionInstance error(SessionCredentials creds, HTTPTriggerConnection tc, JsonFilterActionInstance jfai, Throwable e)
       throws SocketNotAvailableException {
     AuthUtils.replyError(tc, jfai, Status.unauthorized, e);

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
@@ -26,23 +26,18 @@ import com.gip.xyna.XynaFactory;
 import com.gip.xyna.utils.collections.Pair;
 import com.gip.xyna.utils.exceptions.XynaException;
 import com.gip.xyna.utils.misc.JsonBuilder;
+import com.gip.xyna.xact.filter.ConfigurableFilterAction;
 import com.gip.xyna.xact.filter.FilterAction;
+import com.gip.xyna.xact.filter.H5XdevFilterParameter;
 import com.gip.xyna.xact.filter.HTMLBuilder.HTMLPart;
 import com.gip.xyna.xact.filter.JsonFilterActionInstance;
 import com.gip.xyna.xact.filter.URLPath;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection.Method;
-import com.gip.xyna.xdev.xfractmod.xmdm.Container;
-import com.gip.xyna.xdev.xfractmod.xmdm.GeneralXynaObject;
-import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
 import com.gip.xyna.xfmg.xopctrl.DomainTypeSpecificData;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.Domain;
-import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainName;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainType;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.RolesResolver;
-import com.gip.xyna.xprc.XynaOrderCreationParameter;
-import com.gip.xyna.xprc.XynaOrderServerExtension;
-import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
 
 
 
@@ -86,19 +81,13 @@ import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
  * <Error-Response>
  *
  */
-public class ExternalUserLoginInformationAction implements FilterAction {
+public class ExternalUserLoginInformationAction implements ConfigurableFilterAction {
 
   private static final String USERNAME = "username";
   private static final String DISPLAY_NAME = "userdisplayname";
   private static final String EXTERNAL_DOMAINS = "externaldomains";
   private static final String DOMAIN_NAME = "name";
   private static final String DOMAIN_ROLES = "roles";
-  private static volatile String preferredDomainName = "";
-
-
-  public static void setPreferredDomainName(String preferredDomain) {
-    preferredDomainName = preferredDomain == null ? "" : preferredDomain.trim();
-  }
 
 
   public boolean match(URLPath url, Method method) {
@@ -106,10 +95,28 @@ public class ExternalUserLoginInformationAction implements FilterAction {
   }
 
 
+  /**
+   * Config-aware entry point called by H5XdevFilter.
+   */
+  @Override
+  public FilterActionInstance actWithConfig(URLPath url, HTTPTriggerConnection tc, H5XdevFilterParameter config) throws XynaException {
+    return doAct(url, tc, config);
+  }
+
+
+  /**
+   * Legacy entry point - called when no config is passed (backward compatibility).
+   */
+  @Override
   public FilterActionInstance act(URLPath url, HTTPTriggerConnection tc) throws XynaException {
+    return doAct(url, tc, H5XdevFilterParameter.createDefaultConfig());
+  }
+
+
+  private FilterActionInstance doAct(URLPath url, HTTPTriggerConnection tc, H5XdevFilterParameter config) throws XynaException {
     JsonFilterActionInstance jfai = new JsonFilterActionInstance();
 
-    Pair<Boolean, ExternalUserInfo> p = ExternalUserLoginAction.getExternalUserInfoOrFail(jfai, tc);
+    Pair<Boolean, ExternalUserInfo> p = ExternalUserLoginAction.getExternalUserInfoOrFail(jfai, tc, config);
     if (p.getFirst()) {
       return jfai;
     }
@@ -118,6 +125,8 @@ public class ExternalUserLoginInformationAction implements FilterAction {
       jfai.sendJson(tc, "{}");
       return jfai;
     }
+
+    String preferredDomainName = config.getPreferredDomain() != null ? config.getPreferredDomain().trim() : "";
 
     JsonBuilder jb = new JsonBuilder();
     jb.startObject();

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
@@ -22,10 +22,6 @@ package com.gip.xyna.xact.filter.actions.auth;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.log4j.Logger;
-
-import com.gip.xyna.CentralFactoryLogging;
 import com.gip.xyna.XynaFactory;
 import com.gip.xyna.utils.collections.Pair;
 import com.gip.xyna.utils.exceptions.XynaException;
@@ -92,13 +88,17 @@ import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
  */
 public class ExternalUserLoginInformationAction implements FilterAction {
 
-  private static final Logger logger = CentralFactoryLogging.getLogger(ExternalUserLoginInformationAction.class);
-
   private static final String USERNAME = "username";
   private static final String DISPLAY_NAME = "userdisplayname";
   private static final String EXTERNAL_DOMAINS = "externaldomains";
   private static final String DOMAIN_NAME = "name";
   private static final String DOMAIN_ROLES = "roles";
+  private static volatile String preferredDomainName = "";
+
+
+  public static void setPreferredDomainName(String preferredDomain) {
+    preferredDomainName = preferredDomain == null ? "" : preferredDomain.trim();
+  }
 
 
   public boolean match(URLPath url, Method method) {
@@ -127,8 +127,6 @@ public class ExternalUserLoginInformationAction implements FilterAction {
     List<String> domainNames = new ArrayList<>();
     List<Map<String, Object>> domainsList = new ArrayList<>();
 
-    String preferredDomainName = null;
-
     for (Domain d : XynaFactory.getInstance().getFactoryManagement().getDomains()) {
       if (d.getDomainTypeAsEnum() != DomainType.LOCAL) {
         domainNames.add(d.getName());
@@ -140,16 +138,6 @@ public class ExternalUserLoginInformationAction implements FilterAction {
         domainInfo.put(DOMAIN_NAME, d.getName());
         domainInfo.put(DOMAIN_ROLES, roles);
         domainsList.add(domainInfo);
-
-        // Check if this domain has a preferred domain setting
-        if (preferredDomainName == null && d.getDomainSpecificData() instanceof com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData) {
-          com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData jwtData =
-              (com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData) d.getDomainSpecificData();
-          java.util.Optional<String> pref = jwtData.getPreferredDomain();
-          if (pref.isPresent()) {
-            preferredDomainName = pref.get();
-          }
-        }
       }
     }
 

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
@@ -1,6 +1,6 @@
 /*
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
+ * Copyright 2026 Xyna GmbH, Germany
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,11 @@ package com.gip.xyna.xact.filter.actions.auth;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
+import org.apache.log4j.Logger;
+
+import com.gip.xyna.CentralFactoryLogging;
 import com.gip.xyna.XynaFactory;
 import com.gip.xyna.utils.collections.Pair;
 import com.gip.xyna.utils.exceptions.XynaException;
@@ -32,15 +36,22 @@ import com.gip.xyna.xact.filter.JsonFilterActionInstance;
 import com.gip.xyna.xact.filter.URLPath;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection.Method;
+import com.gip.xyna.xdev.xfractmod.xmdm.Container;
+import com.gip.xyna.xdev.xfractmod.xmdm.GeneralXynaObject;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.Domain;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainName;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainType;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
+import com.gip.xyna.xprc.XynaOrderCreationParameter;
+import com.gip.xyna.xprc.XynaOrderServerExtension;
+import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
 
 
 
 /**
- * http (reverse) proxy schickt client zertifikat als payload an xyna. z.b. könnte das der apache machen.
+ * http (reverse) proxy schickt client zertifikat als payload an xyna. z.b. kï¿½nnte das der apache machen.
  * vgl https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/valves/SSLValve.html (beschreibung, wie das im tomcat terminiert)
- * 
+ *
  * beispiel request:
  * GET /FractalModeller/ HTTP/1.1
 Host: 10.0.10.141:7443
@@ -53,15 +64,15 @@ Upgrade-Insecure-Requests: 1
 If-Modified-Since: Mon, 06 Aug 2018 07:44:55 GMT
 If-None-Match: W/"4416-1533541495000"
 Cache-Control: max-age=0
-SSL_CLIENT_CERT: -----BEGIN CERTIFICATE----- MIIDiTCCAnECCQDtSB9W0GaqOTANBgkqhkiG9w0BAQUFADCBgzELMAkGA1UEBhMC REUxGDAWBgNVBAgMD1JoZWlubGFuZCBQZmFsejEOMAwGA1UEBwwFTWFpbnoxDDAK BgNVBAoMA0dJUDEMMAoGA1UECwwDREVWMREwDwYDVQQDDAh2bWxpbjA1NzEbMBkG CSqGSIb3DQEJARYMYXhlbEBoaWVyLmRlMB4XDTE1MDYxMjEyMTQzNVoXDTI1MDQy MDEyMTQzNVowgYgxDzANBgNVBAMMBkxldmVsMTEOMAwGA1UECwwFVXNlcnMxETAP BgNVBAsMCEN1c3RvbWVyMRkwFwYKCZImiZPyLGQBGRYJbmdzc20tZ2lwMRIwEAYK CZImiZPyLGQBGRYCenoxIzAhBgkqhkiG9w0BCQEWFEdJUC5MZXZlbDFAZ2lwLmxv Y2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyIFBkqZqSg4aylyI Uyv7lwklN60mLPwPP6Wksz+QE8Btfv8L6sFcoSzzHYwhDg5Tn5sD10p9WX9z0Mta mWg69oRtOiGbfJwswWZvCF1qD2U+bhiADsBlPdrFnjjYk8kaNGlamX+kLqv5mdK6 cStILuqj5nXlpZ8kidqJAuyh5EQoD8c26t3lSlFMo9Sa+Rz8HrVkM8xGCq24FS+G F6tvLFGxHegeWUR4Ty+luzFK9CHJhsXcB9CyPsPe1ibWp7i94CSazKv6YcLid3ZE 6k4S8XCJhh9s01zVAG0eP34V765XqCeZNnxVIA4xsUV6/P1PCqrCCPY2OJGMykF1 OClGgQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQC2qk2h6UIAmLZQSrQkleiFRzIP EAMvBttVUpIksHoUEVeKiNajhJFjDsAN0DXnzzlCW2GiJyQXulbiI1rHCqMRK0b6 WSst7/HMV2xBsmAEYGrMNDtLpcjEkttwbEwRm8rtIquqQolp+XOPyRPEqXLe2wtz j2MfO9lCe5Tj89XInFW8sj9F4SwNWHCjOyoYBENy1I2dhfUG0UcG1sWQcVAggKQO fleYGSpS6DaENp9sttR0M0OxDVYuygqBG767jZaAHxdjykzgiEyO2tLCOzfTIUN3 0npArZ96b9p7pELz93RZJdQZCqopp9we5kITqxjSkN15QHuah6Vyq23hOUhb -----END CERTIFICATE----- 
+SSL_CLIENT_CERT: -----BEGIN CERTIFICATE----- MIIDiTCCAnECCQDtSB9W0GaqOTANBgkqhkiG9w0BAQUFADCBgzELMAkGA1UEBhMC REUxGDAWBgNVBAgMD1JoZWlubGFuZCBQZmFsejEOMAwGA1UEBwwFTWFpbnoxDDAK BgNVBAoMA0dJUDEMMAoGA1UECwwDREVWMREwDwYDVQQDDAh2bWxpbjA1NzEbMBkG CSqGSIb3DQEJARYMYXhlbEBoaWVyLmRlMB4XDTE1MDYxMjEyMTQzNVoXDTI1MDQy MDEyMTQzNVowgYgxDzANBgNVBAMMBkxldmVsMTEOMAwGA1UECwwFVXNlcnMxETAP BgNVBAsMCEN1c3RvbWVyMRkwFwYKCZImiZPyLGQBGRYJbmdzc20tZ2lwMRIwEAYK CZImiZPyLGQBGRYCenoxIzAhBgkqhkiG9w0BCQEWFEdJUC5MZXZlbDFAZ2lwLmxv Y2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyIFBkqZqSg4aylyI Uyv7lwklN60mLPwPP6Wksz+QE8Btfv8L6sFcoSzzHYwhDg5Tn5sD10p9WX9z0Mta mWg69oRtOiGbfJwswWZvCF1qD2U+bhiADsBlPdrFnjjYk8kaNGlamX+kLqv5mdK6 cStILuqj5nXlpZ8kidqJAuyh5EQoD8c26t3lSlFMo9Sa+Rz8HrVkM8xGCq24FS+G F6tvLFGxHegeWUR4Ty+luzFK9CHJhsXcB9CyPsPe1ibWp7i94CSazKv6YcLid3ZE 6k4S8XCJhh9s01zVAG0eP34V765XqCeZNnxVIA4xsUV6/P1PCqrCCPY2OJGMykF1 OClGgQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQC2qk2h6UIAmLZQSrQkleiFRzIP EAMvBttVUpIksHoUEVeKiNajhJFjDsAN0DXnzzlCW2GiJyQXulbiI1rHCqMRK0b6 WSst7/HMV2xBsmAEYGrMNDtLpcjEkttwbEwRm8rtIquqQolp+XOPyRPEqXLe2wtz j2MfO9lCe5Tj89XInFW8sj9F4SwNWHCjOyoYBENy1I2dhfUG0UcG1sWQcVAggKQO fleYGSpS6DaENp9sttR0M0OxDVYuygqBG767jZaAHxdjykzgiEyO2tLCOzfTIUN3 0npArZ96b9p7pELz93RZJdQZCqopp9we5kITqxjSkN15QHuah6Vyq23hOUhb -----END CERTIFICATE-----
 SSL_CIPHER: ECDHE-RSA-AES128-GCM-SHA256
 SSL_SESSION_ID: 90247e6aeb59ea2f424e656497dc29369a5d1b6b27b766b79f8561a6d2d118fb
 SSL_CIPHER_USEKEYSIZE: 128
-X-Forwarded-For: 
-X-Forwarded-Host: 
-X-Forwarded-Server: 
+X-Forwarded-For:
+X-Forwarded-Host:
+X-Forwarded-Server:
 Connection: Keep-Alive
- * 
+ *
  *
  * Response:
  * {
@@ -69,20 +80,25 @@ Connection: Keep-Alive
  "userdisplayname":"ME.Level1",
  "externaldomains": ["MY_DOMAIN"]
   }
- * 
+ *
  * Response wenn kein Zert vorhanden:
  * {}
- * 
- * Response bei ungültigem Zert:
+ *
+ * Response bei ungÃ¼ltigem Zert:
  * <Error-Response>
- * 
+ *
  */
 public class ExternalUserLoginInformationAction implements FilterAction {
 
+  private static final Logger logger = CentralFactoryLogging.getLogger(ExternalUserLoginInformationAction.class);
+  private static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
+  private static final String RESOLVE_ROLES_WORKFLOW = "xact.http.jwt.auth.ResolveAvailableRolesWithJWT";
 
   private static final String USERNAME = "username";
   private static final String DISPLAY_NAME = "userdisplayname";
   private static final String EXTERNAL_DOMAINS = "externaldomains";
+  private static final String DOMAIN_NAME = "name";
+  private static final String DOMAIN_ROLES = "roles";
 
 
   public boolean match(URLPath url, Method method) {
@@ -108,17 +124,101 @@ public class ExternalUserLoginInformationAction implements FilterAction {
     jb.addStringAttribute(USERNAME, eui.externalUserName);
     jb.addStringAttribute(DISPLAY_NAME, eui.externalUserDisplayName);
 
-    List<String> domains = new ArrayList<>();
+    List<String> domainNames = new ArrayList<>();
+    List<Map<String, Object>> domainsList = new ArrayList<>();
+
     for (Domain d : XynaFactory.getInstance().getFactoryManagement().getDomains()) {
       if (d.getDomainTypeAsEnum() != DomainType.LOCAL) {
-        domains.add(d.getName());
+        domainNames.add(d.getName());
+
+        // Get available roles for this domain
+        List<String> roles = getAvailableRolesForDomain(d, eui);
+
+        Map<String, Object> domainInfo = new java.util.LinkedHashMap<>();
+        domainInfo.put(DOMAIN_NAME, d.getName());
+        domainInfo.put(DOMAIN_ROLES, roles);
+        domainsList.add(domainInfo);
       }
     }
-    jb.addStringListAttribute(EXTERNAL_DOMAINS, domains);
+
+    jb.addStringListAttribute(EXTERNAL_DOMAINS, domainNames);
+
+    // Add detailed domain information with roles
+    if (!domainsList.isEmpty()) {
+      jb.nextObjectAsAttribute("domains");
+      jb.startList();
+      for (Map<String, Object> domainInfo : domainsList) {
+        jb.startObject();
+        jb.addStringAttribute(DOMAIN_NAME, (String) domainInfo.get(DOMAIN_NAME));
+        @SuppressWarnings("unchecked")
+        List<String> roles = (List<String>) domainInfo.get(DOMAIN_ROLES);
+        jb.addStringListAttribute(DOMAIN_ROLES, roles);
+        jb.endObject();
+      }
+      jb.endList();
+    }
+
     jb.endObject();
 
     jfai.sendJson(tc, jb.toString());
     return jfai;
+  }
+
+
+  private List<String> getAvailableRolesForDomain(Domain domain, ExternalUserInfo eui) {
+    List<String> roles = new ArrayList<>();
+
+    // Only for JWT domains
+    if (domain.getDomainTypeAsEnum() != DomainType.JWT) {
+      return roles;
+    }
+
+    String token = eui.externalUserPassword;
+    if (token == null || token.isEmpty()) {
+      return roles;
+    }
+    try {
+      JWTDomainSpecificData dsd = (JWTDomainSpecificData) domain.getDomainSpecificData();
+
+      // Call ResolveAvailableRolesWithJWT workflow in the JSONWebToken application.
+      // Token is injected via OrderContext, identical to JWTUserAuthentication.generateAuthOrder.
+      DomainName domainNameObj = new DomainName(domain.getName());
+      DestinationKey dk = new DestinationKey(RESOLVE_ROLES_WORKFLOW, dsd.getRuntimeContext());
+      XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(dk, domainNameObj);
+      XynaOrderServerExtension xose = new XynaOrderServerExtension(xocp);
+      xose.setNewOrderContext();
+      xose.getOrderContext().set(ORDER_CONTEXT_KEY_JWT_TOKEN, token);
+
+      XynaOrderServerExtension resultOrder =
+          XynaFactory.getInstance().getProcessing().getXynaProcessCtrlExecution().startOrderSynchronous(xose);
+
+      GeneralXynaObject output = resultOrder.getOutputPayload();
+      if (output instanceof List<?>) {
+        for (Object itemObj : (List<?>) output) {
+          if (itemObj instanceof GeneralXynaObject) {
+            Object textVal = ((GeneralXynaObject) itemObj).get("text");
+            if (textVal instanceof String && !((String) textVal).isEmpty()) {
+              roles.add((String) textVal);
+            }
+          }
+        }
+      } else if (output instanceof Container) {
+        Container c = (Container) output;
+        for (int i = 0; i < c.size(); i++) {
+          GeneralXynaObject item = c.get(i);
+          if (item != null) {
+            Object textVal = item.get("text");
+            if (textVal instanceof String && !((String) textVal).isEmpty()) {
+              roles.add((String) textVal);
+            }
+          }
+        }
+      }
+    } catch (Exception e) {
+      logger.debug("Could not resolve available roles for JWT domain '" + domain.getName() + "': " + e.getMessage());
+    }
+
+    return roles;
   }
 
 

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
@@ -127,6 +127,8 @@ public class ExternalUserLoginInformationAction implements FilterAction {
     List<String> domainNames = new ArrayList<>();
     List<Map<String, Object>> domainsList = new ArrayList<>();
 
+    String preferredDomainName = null;
+
     for (Domain d : XynaFactory.getInstance().getFactoryManagement().getDomains()) {
       if (d.getDomainTypeAsEnum() != DomainType.LOCAL) {
         domainNames.add(d.getName());
@@ -138,7 +140,38 @@ public class ExternalUserLoginInformationAction implements FilterAction {
         domainInfo.put(DOMAIN_NAME, d.getName());
         domainInfo.put(DOMAIN_ROLES, roles);
         domainsList.add(domainInfo);
+
+        // Check if this domain has a preferred domain setting
+        if (preferredDomainName == null && d.getDomainSpecificData() instanceof com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData) {
+          com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData jwtData =
+              (com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData) d.getDomainSpecificData();
+          java.util.Optional<String> pref = jwtData.getPreferredDomain();
+          if (pref.isPresent()) {
+            preferredDomainName = pref.get();
+          }
+        }
       }
+    }
+
+    // Sort domains: preferred domain first if configured
+    if (preferredDomainName != null && !preferredDomainName.isEmpty()) {
+      Map<String, Object> preferredDomainInfo = null;
+      for (Map<String, Object> domainInfo : domainsList) {
+        if (preferredDomainName.equals(domainInfo.get(DOMAIN_NAME))) {
+          preferredDomainInfo = domainInfo;
+          break;
+        }
+      }
+      if (preferredDomainInfo != null) {
+        domainsList.remove(preferredDomainInfo);
+        domainsList.add(0, preferredDomainInfo);
+      }
+    }
+
+    // Keep externaldomains in the same order as domains.
+    domainNames.clear();
+    for (Map<String, Object> domainInfo : domainsList) {
+      domainNames.add((String) domainInfo.get(DOMAIN_NAME));
     }
 
     jb.addStringListAttribute(EXTERNAL_DOMAINS, domainNames);
@@ -176,63 +209,12 @@ public class ExternalUserLoginInformationAction implements FilterAction {
       return roles;
     }
 
-    try {
-      String resolveRolesWorkflow = null;
-      RuntimeContext runtimeContext = null;
-      String rolesResolverOrderContextKey = null;
-
-      if (!(domainSpecificData instanceof RolesResolver)) {
-        return roles;
-      }
-
-      RolesResolver resolverConfig = (RolesResolver) domainSpecificData;
-      resolveRolesWorkflow = resolverConfig.getRolesResolverOrdertype().orElse(null);
-      runtimeContext = resolverConfig.getRolesResolverRuntimeContext();
-      rolesResolverOrderContextKey = resolverConfig.getRolesResolverOrderContextKey();
-
-      if (resolveRolesWorkflow == null || resolveRolesWorkflow.isEmpty() || runtimeContext == null || rolesResolverOrderContextKey == null || rolesResolverOrderContextKey.isEmpty()) {
-        return roles;
-      }
-
-      // Call configured resolve-available-roles workflow.
-      // Credential is injected via OrderContext, aligned with JWTUserAuthentication.generateAuthOrder.
-      DomainName domainNameObj = new DomainName(domain.getName());
-      DestinationKey destKey = new DestinationKey(resolveRolesWorkflow, runtimeContext);
-      XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(destKey, domainNameObj);
-      XynaOrderServerExtension xose = new XynaOrderServerExtension(xocp);
-      xose.setNewOrderContext();
-      xose.getOrderContext().set(rolesResolverOrderContextKey, token);
-
-      XynaOrderServerExtension resultOrder =
-          XynaFactory.getInstance().getProcessing().getXynaProcessCtrlExecution().startOrderSynchronous(xose);
-
-      GeneralXynaObject output = resultOrder.getOutputPayload();
-      if (output instanceof List<?>) {
-        for (Object itemObj : (List<?>) output) {
-          if (itemObj instanceof GeneralXynaObject) {
-            Object textVal = ((GeneralXynaObject) itemObj).get("text");
-            if (textVal instanceof String && !((String) textVal).isEmpty()) {
-              roles.add((String) textVal);
-            }
-          }
-        }
-      } else if (output instanceof Container) {
-        Container c = (Container) output;
-        for (int i = 0; i < c.size(); i++) {
-          GeneralXynaObject item = c.get(i);
-          if (item != null) {
-            Object textVal = item.get("text");
-            if (textVal instanceof String && !((String) textVal).isEmpty()) {
-              roles.add((String) textVal);
-            }
-          }
-        }
-      }
-    } catch (Exception e) {
-      logger.debug("Could not resolve available roles for domain '" + domain.getName() + "': " + e.getMessage());
+    if (!(domainSpecificData instanceof RolesResolver)) {
+      return roles;
     }
 
-    return roles;
+    RolesResolver resolverConfig = (RolesResolver) domainSpecificData;
+    return resolverConfig.resolveAvailableRoles(domain.getName(), token);
   }
 
 

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
@@ -21,13 +21,11 @@ package com.gip.xyna.xact.filter.actions.auth;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import com.gip.xyna.XynaFactory;
 import com.gip.xyna.utils.collections.Pair;
 import com.gip.xyna.utils.exceptions.XynaException;
 import com.gip.xyna.utils.misc.JsonBuilder;
 import com.gip.xyna.xact.filter.ConfigurableFilterAction;
-import com.gip.xyna.xact.filter.FilterAction;
 import com.gip.xyna.xact.filter.H5XdevFilterParameter;
 import com.gip.xyna.xact.filter.HTMLBuilder.HTMLPart;
 import com.gip.xyna.xact.filter.JsonFilterActionInstance;
@@ -90,6 +88,15 @@ public class ExternalUserLoginInformationAction implements ConfigurableFilterAct
   private static final String DOMAIN_ROLES = "roles";
 
 
+  /**
+   * Typed wrapper for domain roles to avoid casts and type warnings.
+   */
+  private static class DomainRoles {
+    String name;
+    List<String> roles;
+  }
+
+
   public boolean match(URLPath url, Method method) {
     return url.getPath().startsWith("/auth/externalUserLoginInformation") && Method.GET == method;
   }
@@ -134,7 +141,7 @@ public class ExternalUserLoginInformationAction implements ConfigurableFilterAct
     jb.addStringAttribute(DISPLAY_NAME, eui.externalUserDisplayName);
 
     List<String> domainNames = new ArrayList<>();
-    List<Map<String, Object>> domainsList = new ArrayList<>();
+    List<DomainRoles> domainsList = new ArrayList<>();
 
     for (Domain d : XynaFactory.getInstance().getFactoryManagement().getDomains()) {
       if (d.getDomainTypeAsEnum() != DomainType.LOCAL) {
@@ -143,18 +150,18 @@ public class ExternalUserLoginInformationAction implements ConfigurableFilterAct
         // Get available roles for this domain
         List<String> roles = getAvailableRolesForDomain(d, eui);
 
-        Map<String, Object> domainInfo = new java.util.LinkedHashMap<>();
-        domainInfo.put(DOMAIN_NAME, d.getName());
-        domainInfo.put(DOMAIN_ROLES, roles);
+        DomainRoles domainInfo = new DomainRoles();
+        domainInfo.name = d.getName();
+        domainInfo.roles = roles;
         domainsList.add(domainInfo);
       }
     }
 
     // Sort domains: preferred domain first if configured
     if (preferredDomainName != null && !preferredDomainName.isEmpty()) {
-      Map<String, Object> preferredDomainInfo = null;
-      for (Map<String, Object> domainInfo : domainsList) {
-        if (preferredDomainName.equals(domainInfo.get(DOMAIN_NAME))) {
+      DomainRoles preferredDomainInfo = null;
+      for (DomainRoles domainInfo : domainsList) {
+        if (preferredDomainName.equals(domainInfo.name)) {
           preferredDomainInfo = domainInfo;
           break;
         }
@@ -167,8 +174,8 @@ public class ExternalUserLoginInformationAction implements ConfigurableFilterAct
 
     // Keep externaldomains in the same order as domains.
     domainNames.clear();
-    for (Map<String, Object> domainInfo : domainsList) {
-      domainNames.add((String) domainInfo.get(DOMAIN_NAME));
+    for (DomainRoles domainInfo : domainsList) {
+      domainNames.add(domainInfo.name);
     }
 
     jb.addStringListAttribute(EXTERNAL_DOMAINS, domainNames);
@@ -177,11 +184,10 @@ public class ExternalUserLoginInformationAction implements ConfigurableFilterAct
     if (!domainsList.isEmpty()) {
       jb.nextObjectAsAttribute("domains");
       jb.startList();
-      for (Map<String, Object> domainInfo : domainsList) {
+      for (DomainRoles domainInfo : domainsList) {
         jb.startObject();
-        jb.addStringAttribute(DOMAIN_NAME, (String) domainInfo.get(DOMAIN_NAME));
-        @SuppressWarnings("unchecked") List<String> roles = (List<String>) domainInfo.get(DOMAIN_ROLES);
-        jb.addStringListAttribute(DOMAIN_ROLES, roles);
+        jb.addStringAttribute(DOMAIN_NAME, domainInfo.name);
+        jb.addStringListAttribute(DOMAIN_ROLES, domainInfo.roles);
         jb.endObject();
       }
       jb.endList();

--- a/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
+++ b/modules/xmcp/guihttp/filterimpl/H5XdevFilter/src/com/gip/xyna/xact/filter/actions/auth/ExternalUserLoginInformationAction.java
@@ -38,10 +38,12 @@ import com.gip.xyna.xact.trigger.HTTPTriggerConnection;
 import com.gip.xyna.xact.trigger.HTTPTriggerConnection.Method;
 import com.gip.xyna.xdev.xfractmod.xmdm.Container;
 import com.gip.xyna.xdev.xfractmod.xmdm.GeneralXynaObject;
+import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
+import com.gip.xyna.xfmg.xopctrl.DomainTypeSpecificData;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.Domain;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainName;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainType;
-import com.gip.xyna.xfmg.xopctrl.usermanagement.jwt.JWTDomainSpecificData;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.RolesResolver;
 import com.gip.xyna.xprc.XynaOrderCreationParameter;
 import com.gip.xyna.xprc.XynaOrderServerExtension;
 import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
@@ -49,29 +51,29 @@ import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
 
 
 /**
- * http (reverse) proxy schickt client zertifikat als payload an xyna. z.b. kï¿½nnte das der apache machen.
+ * http (reverse) proxy schickt client zertifikat als payload an xyna. z.b. könnte das der apache machen.
  * vgl https://tomcat.apache.org/tomcat-8.5-doc/api/org/apache/catalina/valves/SSLValve.html (beschreibung, wie das im tomcat terminiert)
  *
  * beispiel request:
  * GET /FractalModeller/ HTTP/1.1
-Host: 10.0.10.141:7443
-User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0
-Accept: text/html,application/xhtml+xml,application/xml;q=0.9,* /*;q=0.8
-Accept-Language: de,en-US;q=0.7,en;q=0.3
-Accept-Encoding: gzip, deflate, br
-DNT: 1
-Upgrade-Insecure-Requests: 1
-If-Modified-Since: Mon, 06 Aug 2018 07:44:55 GMT
-If-None-Match: W/"4416-1533541495000"
-Cache-Control: max-age=0
-SSL_CLIENT_CERT: -----BEGIN CERTIFICATE----- MIIDiTCCAnECCQDtSB9W0GaqOTANBgkqhkiG9w0BAQUFADCBgzELMAkGA1UEBhMC REUxGDAWBgNVBAgMD1JoZWlubGFuZCBQZmFsejEOMAwGA1UEBwwFTWFpbnoxDDAK BgNVBAoMA0dJUDEMMAoGA1UECwwDREVWMREwDwYDVQQDDAh2bWxpbjA1NzEbMBkG CSqGSIb3DQEJARYMYXhlbEBoaWVyLmRlMB4XDTE1MDYxMjEyMTQzNVoXDTI1MDQy MDEyMTQzNVowgYgxDzANBgNVBAMMBkxldmVsMTEOMAwGA1UECwwFVXNlcnMxETAP BgNVBAsMCEN1c3RvbWVyMRkwFwYKCZImiZPyLGQBGRYJbmdzc20tZ2lwMRIwEAYK CZImiZPyLGQBGRYCenoxIzAhBgkqhkiG9w0BCQEWFEdJUC5MZXZlbDFAZ2lwLmxv Y2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyIFBkqZqSg4aylyI Uyv7lwklN60mLPwPP6Wksz+QE8Btfv8L6sFcoSzzHYwhDg5Tn5sD10p9WX9z0Mta mWg69oRtOiGbfJwswWZvCF1qD2U+bhiADsBlPdrFnjjYk8kaNGlamX+kLqv5mdK6 cStILuqj5nXlpZ8kidqJAuyh5EQoD8c26t3lSlFMo9Sa+Rz8HrVkM8xGCq24FS+G F6tvLFGxHegeWUR4Ty+luzFK9CHJhsXcB9CyPsPe1ibWp7i94CSazKv6YcLid3ZE 6k4S8XCJhh9s01zVAG0eP34V765XqCeZNnxVIA4xsUV6/P1PCqrCCPY2OJGMykF1 OClGgQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQC2qk2h6UIAmLZQSrQkleiFRzIP EAMvBttVUpIksHoUEVeKiNajhJFjDsAN0DXnzzlCW2GiJyQXulbiI1rHCqMRK0b6 WSst7/HMV2xBsmAEYGrMNDtLpcjEkttwbEwRm8rtIquqQolp+XOPyRPEqXLe2wtz j2MfO9lCe5Tj89XInFW8sj9F4SwNWHCjOyoYBENy1I2dhfUG0UcG1sWQcVAggKQO fleYGSpS6DaENp9sttR0M0OxDVYuygqBG767jZaAHxdjykzgiEyO2tLCOzfTIUN3 0npArZ96b9p7pELz93RZJdQZCqopp9we5kITqxjSkN15QHuah6Vyq23hOUhb -----END CERTIFICATE-----
-SSL_CIPHER: ECDHE-RSA-AES128-GCM-SHA256
-SSL_SESSION_ID: 90247e6aeb59ea2f424e656497dc29369a5d1b6b27b766b79f8561a6d2d118fb
-SSL_CIPHER_USEKEYSIZE: 128
-X-Forwarded-For:
-X-Forwarded-Host:
-X-Forwarded-Server:
-Connection: Keep-Alive
+ Host: 10.0.10.141:7443
+ User-Agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0
+ Accept: text/html,application/xhtml+xml,application/xml;q=0.9,* /*;q=0.8
+ Accept-Language: de,en-US;q=0.7,en;q=0.3
+ Accept-Encoding: gzip, deflate, br
+ DNT: 1
+ Upgrade-Insecure-Requests: 1
+ If-Modified-Since: Mon, 06 Aug 2018 07:44:55 GMT
+ If-None-Match: W/"4416-1533541495000"
+ Cache-Control: max-age=0
+ SSL_CLIENT_CERT: -----BEGIN CERTIFICATE----- MIIDiTCCAnECCQDtSB9W0GaqOTANBgkqhkiG9w0BAQUFADCBgzELMAkGA1UEBhMC REUxGDAWBgNVBAgMD1JoZWlubGFuZCBQZmFsejEOMAwGA1UEBwwFTWFpbnoxDDAK BgNVBAoMA0dJUDEMMAoGA1UECwwDREVWMREwDwYDVQQDDAh2bWxpbjA1NzEbMBkG CSqGSIb3DQEJARYMYXhlbEBoaWVyLmRlMB4XDTE1MDYxMjEyMTQzNVoXDTI1MDQy MDEyMTQzNVowgYgxDzANBgNVBAMMBkxldmVsMTEOMAwGA1UECwwFVXNlcnMxETAP BgNVBAsMCEN1c3RvbWVyMRkwFwYKCZImiZPyLGQBGRYJbmdzc20tZ2lwMRIwEAYK CZImiZPyLGQBGRYCenoxIzAhBgkqhkiG9w0BCQEWFEdJUC5MZXZlbDFAZ2lwLmxv Y2FsMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyIFBkqZqSg4aylyI Uyv7lwklN60mLPwPP6Wksz+QE8Btfv8L6sFcoSzzHYwhDg5Tn5sD10p9WX9z0Mta mWg69oRtOiGbfJwswWZvCF1qD2U+bhiADsBlPdrFnjjYk8kaNGlamX+kLqv5mdK6 cStILuqj5nXlpZ8kidqJAuyh5EQoD8c26t3lSlFMo9Sa+Rz8HrVkM8xGCq24FS+G F6tvLFGxHegeWUR4Ty+luzFK9CHJhsXcB9CyPsPe1ibWp7i94CSazKv6YcLid3ZE 6k4S8XCJhh9s01zVAG0eP34V765XqCeZNnxVIA4xsUV6/P1PCqrCCPY2OJGMykF1 OClGgQIDAQABMA0GCSqGSIb3DQEBBQUAA4IBAQC2qk2h6UIAmLZQSrQkleiFRzIP EAMvBttVUpIksHoUEVeKiNajhJFjDsAN0DXnzzlCW2GiJyQXulbiI1rHCqMRK0b6 WSst7/HMV2xBsmAEYGrMNDtLpcjEkttwbEwRm8rtIquqQolp+XOPyRPEqXLe2wtz j2MfO9lCe5Tj89XInFW8sj9F4SwNWHCjOyoYBENy1I2dhfUG0UcG1sWQcVAggKQO fleYGSpS6DaENp9sttR0M0OxDVYuygqBG767jZaAHxdjykzgiEyO2tLCOzfTIUN3 0npArZ96b9p7pELz93RZJdQZCqopp9we5kITqxjSkN15QHuah6Vyq23hOUhb -----END CERTIFICATE-----
+ SSL_CIPHER: ECDHE-RSA-AES128-GCM-SHA256
+ SSL_SESSION_ID: 90247e6aeb59ea2f424e656497dc29369a5d1b6b27b766b79f8561a6d2d118fb
+ SSL_CIPHER_USEKEYSIZE: 128
+ X-Forwarded-For:
+ X-Forwarded-Host:
+ X-Forwarded-Server:
+ Connection: Keep-Alive
  *
  *
  * Response:
@@ -79,20 +81,18 @@ Connection: Keep-Alive
  "username":"ME.Level1@myCorp.local",
  "userdisplayname":"ME.Level1",
  "externaldomains": ["MY_DOMAIN"]
-  }
+ }
  *
  * Response wenn kein Zert vorhanden:
  * {}
  *
- * Response bei ungÃ¼ltigem Zert:
+ * Response bei ungültigem Zert:
  * <Error-Response>
  *
  */
 public class ExternalUserLoginInformationAction implements FilterAction {
 
   private static final Logger logger = CentralFactoryLogging.getLogger(ExternalUserLoginInformationAction.class);
-  private static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
-  private static final String RESOLVE_ROLES_WORKFLOW = "xact.http.jwt.auth.ResolveAvailableRolesWithJWT";
 
   private static final String USERNAME = "username";
   private static final String DISPLAY_NAME = "userdisplayname";
@@ -150,8 +150,7 @@ public class ExternalUserLoginInformationAction implements FilterAction {
       for (Map<String, Object> domainInfo : domainsList) {
         jb.startObject();
         jb.addStringAttribute(DOMAIN_NAME, (String) domainInfo.get(DOMAIN_NAME));
-        @SuppressWarnings("unchecked")
-        List<String> roles = (List<String>) domainInfo.get(DOMAIN_ROLES);
+        @SuppressWarnings("unchecked") List<String> roles = (List<String>) domainInfo.get(DOMAIN_ROLES);
         jb.addStringListAttribute(DOMAIN_ROLES, roles);
         jb.endObject();
       }
@@ -167,9 +166,8 @@ public class ExternalUserLoginInformationAction implements FilterAction {
 
   private List<String> getAvailableRolesForDomain(Domain domain, ExternalUserInfo eui) {
     List<String> roles = new ArrayList<>();
-
-    // Only for JWT domains
-    if (domain.getDomainTypeAsEnum() != DomainType.JWT) {
+    DomainTypeSpecificData domainSpecificData = domain.getDomainSpecificData();
+    if (domainSpecificData == null) {
       return roles;
     }
 
@@ -177,17 +175,33 @@ public class ExternalUserLoginInformationAction implements FilterAction {
     if (token == null || token.isEmpty()) {
       return roles;
     }
-    try {
-      JWTDomainSpecificData dsd = (JWTDomainSpecificData) domain.getDomainSpecificData();
 
-      // Call ResolveAvailableRolesWithJWT workflow in the JSONWebToken application.
-      // Token is injected via OrderContext, identical to JWTUserAuthentication.generateAuthOrder.
+    try {
+      String resolveRolesWorkflow = null;
+      RuntimeContext runtimeContext = null;
+      String rolesResolverOrderContextKey = null;
+
+      if (!(domainSpecificData instanceof RolesResolver)) {
+        return roles;
+      }
+
+      RolesResolver resolverConfig = (RolesResolver) domainSpecificData;
+      resolveRolesWorkflow = resolverConfig.getRolesResolverOrdertype().orElse(null);
+      runtimeContext = resolverConfig.getRolesResolverRuntimeContext();
+      rolesResolverOrderContextKey = resolverConfig.getRolesResolverOrderContextKey();
+
+      if (resolveRolesWorkflow == null || resolveRolesWorkflow.isEmpty() || runtimeContext == null || rolesResolverOrderContextKey == null || rolesResolverOrderContextKey.isEmpty()) {
+        return roles;
+      }
+
+      // Call configured resolve-available-roles workflow.
+      // Credential is injected via OrderContext, aligned with JWTUserAuthentication.generateAuthOrder.
       DomainName domainNameObj = new DomainName(domain.getName());
-      DestinationKey dk = new DestinationKey(RESOLVE_ROLES_WORKFLOW, dsd.getRuntimeContext());
-      XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(dk, domainNameObj);
+      DestinationKey destKey = new DestinationKey(resolveRolesWorkflow, runtimeContext);
+      XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(destKey, domainNameObj);
       XynaOrderServerExtension xose = new XynaOrderServerExtension(xocp);
       xose.setNewOrderContext();
-      xose.getOrderContext().set(ORDER_CONTEXT_KEY_JWT_TOKEN, token);
+      xose.getOrderContext().set(rolesResolverOrderContextKey, token);
 
       XynaOrderServerExtension resultOrder =
           XynaFactory.getInstance().getProcessing().getXynaProcessCtrlExecution().startOrderSynchronous(xose);
@@ -215,7 +229,7 @@ public class ExternalUserLoginInformationAction implements FilterAction {
         }
       }
     } catch (Exception e) {
-      logger.debug("Could not resolve available roles for JWT domain '" + domain.getName() + "': " + e.getMessage());
+      logger.debug("Could not resolve available roles for domain '" + domain.getName() + "': " + e.getMessage());
     }
 
     return roles;

--- a/modules/xmcp/xypilot/application.xml
+++ b/modules/xmcp/xypilot/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.5</VersionName>
+        <VersionName>1.5.6</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>XyPilotMetricsDefaults</ApplicationName>

--- a/modules/xmcp/xypilot/application.xml
+++ b/modules/xmcp/xypilot/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>GuiHttp</ApplicationName>
-        <VersionName>1.5.6</VersionName>
+        <VersionName>1.5.7</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>XyPilotMetricsDefaults</ApplicationName>

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
@@ -262,11 +262,6 @@ public enum DomainType {
           ? Optional.of(rolesResolverOrdertypeList.get(0))
           : Optional.empty();
 
-      List<String> preferredDomainList = specifics.get("preferredDomain");
-      Optional<String> preferredDomain = (preferredDomainList != null && !preferredDomainList.isEmpty())
-          ? Optional.of(preferredDomainList.get(0))
-          : Optional.empty();
-
       JWTDomainSpecificData.AuthValidationMode authValidationMode = null;
       List<String> validationModeList = specifics.get("authValidationMode");
       if (validationModeList != null && !validationModeList.isEmpty()) {
@@ -279,7 +274,7 @@ public enum DomainType {
       }
 
       JWTDomainSpecificData data = new JWTDomainSpecificData(trustedIssuers, intendedAudience, roleClaimPath, defaultRole,
-          rolePrefix, roleSuffix, roleOrder, jwksUri, configuredOrdertype, rolesResolverOrdertype, revision, preferredDomain);
+          rolePrefix, roleSuffix, roleOrder, jwksUri, configuredOrdertype, rolesResolverOrdertype, revision);
       if (authValidationMode != null) {
         data.setAuthValidationMode(authValidationMode);
       }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
@@ -187,30 +187,31 @@ public enum DomainType {
     @Override
     public JWTDomainSpecificData generateDomainTypeSpecificData(Map<String, List<String>> specifics) {
       List<String> ordertype = specifics.get(JWT_SPECIFIC_ORDERTYPE_PARAMETER_IDENTIFIER);
-      if (ordertype == null || ordertype.isEmpty()) {
-        throw new IllegalArgumentException("No ordertype for authentification!");
-      } else if (ordertype.size() > 1) {
+      if (ordertype != null && ordertype.size() > 1) {
         throw new IllegalArgumentException("Too many ordertypes!");
       }
+      String configuredOrdertype = (ordertype == null || ordertype.isEmpty()) ? null : ordertype.get(0);
+      if (configuredOrdertype != null && configuredOrdertype.trim().isEmpty()) {
+        configuredOrdertype = null;
+      }
 
-      long revision = -1;
       List<String> applications = specifics.get(JWT_SPECIFIC_APPLICATION_PARAMETER_IDENTIFIER);
       List<String> versions = specifics.get(JWT_SPECIFIC_VERSION_PARAMETER_IDENTIFIER);
-      List<String> workspaces = specifics.get(JWT_SPECIFIC_WORKSPACE_PARAMETER_IDENTIFIER);
-      RuntimeContext rc = null;
-      if (applications != null && !applications.isEmpty() && versions != null && !versions.isEmpty()) {
-        rc = new Application(applications.get(0), versions.get(0));
-      } else if (workspaces != null && !workspaces.isEmpty()) {
-        rc = new Workspace(workspaces.get(0));
+      if (applications == null || applications.isEmpty() || versions == null || versions.isEmpty()) {
+        throw new IllegalArgumentException("Missing runtime context for JWT domain: both application and version are required.");
       }
-      if (rc != null) {
-        RevisionManagement revisionManagement = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getRevisionManagement();
-        try {
-          revision = revisionManagement.getRevision(rc);
-        } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e) {
-          CentralFactoryLogging.getLogger(UserManagement.class).warn("Failed to retrieve revision for RuntimeContext " + rc, e);
-          throw new RuntimeException(e);
-        }
+      if (applications.size() > 1 || versions.size() > 1) {
+        throw new IllegalArgumentException("Too many application/version values for JWT runtime context.");
+      }
+
+      RuntimeContext rc = new Application(applications.get(0), versions.get(0));
+      long revision;
+      RevisionManagement revisionManagement = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getRevisionManagement();
+      try {
+        revision = revisionManagement.getRevision(rc);
+      } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e) {
+        CentralFactoryLogging.getLogger(UserManagement.class).warn("Failed to retrieve revision for RuntimeContext " + rc, e);
+        throw new RuntimeException(e);
       }
 
       List<String> trustedIssuers = specifics.get("trustedIssuers");
@@ -261,6 +262,11 @@ public enum DomainType {
           ? Optional.of(rolesResolverOrdertypeList.get(0))
           : Optional.empty();
 
+      List<String> preferredDomainList = specifics.get("preferredDomain");
+      Optional<String> preferredDomain = (preferredDomainList != null && !preferredDomainList.isEmpty())
+          ? Optional.of(preferredDomainList.get(0))
+          : Optional.empty();
+
       JWTDomainSpecificData.AuthValidationMode authValidationMode = null;
       List<String> validationModeList = specifics.get("authValidationMode");
       if (validationModeList != null && !validationModeList.isEmpty()) {
@@ -273,7 +279,7 @@ public enum DomainType {
       }
 
       JWTDomainSpecificData data = new JWTDomainSpecificData(trustedIssuers, intendedAudience, roleClaimPath, defaultRole,
-          rolePrefix, roleSuffix, roleOrder, jwksUri, ordertype.get(0), rolesResolverOrdertype, revision);
+          rolePrefix, roleSuffix, roleOrder, jwksUri, configuredOrdertype, rolesResolverOrdertype, revision, preferredDomain);
       if (authValidationMode != null) {
         data.setAuthValidationMode(authValidationMode);
       }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/DomainType.java
@@ -256,6 +256,10 @@ public enum DomainType {
       Optional<String> defaultRole = (defaultRoleList != null && !defaultRoleList.isEmpty())
           ? Optional.of(defaultRoleList.get(0))
           : Optional.empty();
+      List<String> rolesResolverOrdertypeList = specifics.get("rolesResolverOrdertype");
+      Optional<String> rolesResolverOrdertype = (rolesResolverOrdertypeList != null && !rolesResolverOrdertypeList.isEmpty())
+          ? Optional.of(rolesResolverOrdertypeList.get(0))
+          : Optional.empty();
 
       JWTDomainSpecificData.AuthValidationMode authValidationMode = null;
       List<String> validationModeList = specifics.get("authValidationMode");
@@ -269,7 +273,7 @@ public enum DomainType {
       }
 
       JWTDomainSpecificData data = new JWTDomainSpecificData(trustedIssuers, intendedAudience, roleClaimPath, defaultRole,
-          rolePrefix, roleSuffix, roleOrder, jwksUri, ordertype.get(0), revision);
+          rolePrefix, roleSuffix, roleOrder, jwksUri, ordertype.get(0), rolesResolverOrdertype, revision);
       if (authValidationMode != null) {
         data.setAuthValidationMode(authValidationMode);
       }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
@@ -27,7 +27,7 @@ import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
 
 /**
  * Optional capability for DomainTypeSpecificData implementations that can resolve
- * available login roles through a dedicated workflow.
+ * available login roles.
  */
 public interface RolesResolver {
 
@@ -47,11 +47,11 @@ public interface RolesResolver {
   String getRolesResolverOrderContextKey();
 
   /**
-   * Resolves available login roles for the given domain using the configured RolesResolver workflow.
+   * Resolves available login roles for the given domain.
    * 
    * @param domainName Name of the domain for which roles are resolved
-   * @param credential Credential/token to pass to the resolver workflow
-   * @return List of available role names, empty if resolution fails or workflow not configured
+   * @param credential Credential/token used to determine available roles
+   * @return List of available role names, empty if resolution fails or no roles available
    */
   java.util.List<String> resolveAvailableRoles(String domainName, String credential);
 }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
@@ -32,21 +32,6 @@ import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
 public interface RolesResolver {
 
   /**
-   * Optional ordertype used to resolve available roles for login.
-   */
-  Optional<String> getRolesResolverOrdertype();
-
-  /**
-   * Runtime context where the resolve workflow is located.
-   */
-  RuntimeContext getRolesResolverRuntimeContext();
-
-  /**
-   * OrderContext key under which credential data for the resolver workflow is passed.
-   */
-  String getRolesResolverOrderContextKey();
-
-  /**
    * Resolves available login roles for the given domain.
    * 
    * @param domainName Name of the domain for which roles are resolved

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
@@ -45,5 +45,14 @@ public interface RolesResolver {
    * OrderContext key under which credential data for the resolver workflow is passed.
    */
   String getRolesResolverOrderContextKey();
+
+  /**
+   * Resolves available login roles for the given domain using the configured RolesResolver workflow.
+   * 
+   * @param domainName Name of the domain for which roles are resolved
+   * @param credential Credential/token to pass to the resolver workflow
+   * @return List of available role names, empty if resolution fails or workflow not configured
+   */
+  java.util.List<String> resolveAvailableRoles(String domainName, String credential);
 }
 

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/RolesResolver.java
@@ -1,0 +1,49 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+package com.gip.xyna.xfmg.xopctrl.usermanagement;
+
+
+
+import java.util.Optional;
+
+import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
+
+
+
+/**
+ * Optional capability for DomainTypeSpecificData implementations that can resolve
+ * available login roles through a dedicated workflow.
+ */
+public interface RolesResolver {
+
+  /**
+   * Optional ordertype used to resolve available roles for login.
+   */
+  Optional<String> getRolesResolverOrdertype();
+
+  /**
+   * Runtime context where the resolve workflow is located.
+   */
+  RuntimeContext getRolesResolverRuntimeContext();
+
+  /**
+   * OrderContext key under which credential data for the resolver workflow is passed.
+   */
+  String getRolesResolverOrderContextKey();
+}
+

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
@@ -17,8 +17,12 @@
  */
 package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
 
+
+
 import java.util.List;
 import java.util.Optional;
+
+import org.apache.log4j.Logger;
 
 import com.gip.xyna.CentralFactoryLogging;
 import com.gip.xyna.XynaFactory;
@@ -29,209 +33,276 @@ import com.gip.xyna.xfmg.xopctrl.usermanagement.RolesResolver;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.UserManagement;
 import com.gip.xyna.xnwh.exceptions.XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY;
 
+
+
 public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResolver {
 
-    private static final long serialVersionUID = 1L;
-    private static final String DEFAULT_ROLES_RESOLVER_ORDERTYPE = "xact.http.jwt.auth.ResolveAvailableRolesWithJWT";
+  private static final long serialVersionUID = 1L;
+  private static final String DEFAULT_ASSOCIATED_ORDERTYPE = "xact.http.jwt.auth.AuthenticateWithJWT";
+  private static final String DEFAULT_ROLES_RESOLVER_ORDERTYPE = "xact.http.jwt.auth.ResolveAvailableRolesWithJWT";
 
-    public enum AuthValidationMode {
-        HEADER,
-        JWT
+
+
+  public enum AuthValidationMode {
+    HEADER, JWT
+  }
+
+
+
+  private List<String> trustedIssuers;
+  private List<String> intendedAudience;
+  private String roleClaimPath;
+  private String defaultRole;
+  private String rolePrefix;
+  private String roleSuffix;
+  private List<String> roleOrder;
+  private String jwksUri;
+  private String authValidationMode = AuthValidationMode.JWT.name();
+  private String associatedOrdertype;
+  private String rolesResolverOrdertype;
+  private long revision;
+  private String preferredDomain;
+  private transient RuntimeContext runtimeContext;
+
+
+  public JWTDomainSpecificData() {
+  }
+
+
+  public JWTDomainSpecificData(List<String> trustedIssuers, List<String> intendedAudience, Optional<String> roleClaimPath,
+                               Optional<String> defaultRole, Optional<String> rolePrefix, Optional<String> roleSuffix,
+                               List<String> roleOrder, Optional<String> jwksUri, String associatedOrdertype,
+                               Optional<String> rolesResolverOrdertype, long revision, Optional<String> preferredDomain) {
+    this.trustedIssuers = trustedIssuers;
+    this.intendedAudience = intendedAudience;
+    this.roleClaimPath = roleClaimPath.orElse(null);
+    this.defaultRole = defaultRole.orElse(null);
+    this.rolePrefix = rolePrefix.orElse(null);
+    this.roleSuffix = roleSuffix.orElse(null);
+    this.roleOrder = roleOrder;
+    this.jwksUri = jwksUri.orElse(null);
+    this.associatedOrdertype = associatedOrdertype;
+    this.rolesResolverOrdertype = rolesResolverOrdertype.orElse(null);
+    this.revision = revision;
+    this.preferredDomain = preferredDomain.orElse(null);
+  }
+
+
+  public AuthValidationMode getAuthValidationMode() {
+    try {
+      return AuthValidationMode.valueOf(Optional.ofNullable(authValidationMode).orElse(AuthValidationMode.JWT.name()));
+    } catch (IllegalArgumentException e) {
+      return AuthValidationMode.JWT;
     }
+  }
 
-    private List<String> trustedIssuers;
-    private List<String> intendedAudience;
-    private String roleClaimPath;
-    private String defaultRole;
-    private String rolePrefix;
-    private String roleSuffix;
-    private List<String> roleOrder;
-    private String jwksUri;
-    private String authValidationMode = AuthValidationMode.JWT.name();
-    private String associatedOrdertype;
-    private String rolesResolverOrdertype;
-    private long revision;
-    private transient RuntimeContext runtimeContext;
 
-    public JWTDomainSpecificData() {}
+  public void setAuthValidationMode(AuthValidationMode mode) {
+    this.authValidationMode = (mode != null ? mode : AuthValidationMode.JWT).name();
+  }
 
-    public JWTDomainSpecificData(List<String> trustedIssuers, List<String> intendedAudience,
-                                 Optional<String> roleClaimPath, Optional<String> defaultRole,
-                                 Optional<String> rolePrefix, Optional<String> roleSuffix,
-                                 List<String> roleOrder, Optional<String> jwksUri,
-                                 String associatedOrdertype, Optional<String> rolesResolverOrdertype, long revision) {
-        this.trustedIssuers = trustedIssuers;
-        this.intendedAudience = intendedAudience;
-        this.roleClaimPath = roleClaimPath.orElse(null);
-        this.defaultRole = defaultRole.orElse(null);
-        this.rolePrefix = rolePrefix.orElse(null);
-        this.roleSuffix = roleSuffix.orElse(null);
-        this.roleOrder = roleOrder;
-        this.jwksUri = jwksUri.orElse(null);
-        this.associatedOrdertype = associatedOrdertype;
-        this.rolesResolverOrdertype = rolesResolverOrdertype.orElse(null);
-        this.revision = revision;
+
+  public String getAssociatedOrdertype() {
+    String configured = associatedOrdertype != null ? associatedOrdertype.trim() : null;
+    if (configured == null || configured.isEmpty()) {
+      return DEFAULT_ASSOCIATED_ORDERTYPE;
     }
+    return configured;
+  }
 
-    public AuthValidationMode getAuthValidationMode() {
+
+  public void setAssociatedOrdertype(String associatedOrdertype) {
+    String configured = associatedOrdertype != null ? associatedOrdertype.trim() : null;
+    this.associatedOrdertype = (configured == null || configured.isEmpty()) ? null : configured;
+  }
+
+
+  @Override
+  public Optional<String> getRolesResolverOrdertype() {
+    String configured = rolesResolverOrdertype != null ? rolesResolverOrdertype.trim() : null;
+    if (configured == null || configured.isEmpty()) {
+      return Optional.of(DEFAULT_ROLES_RESOLVER_ORDERTYPE);
+    }
+    return Optional.of(configured);
+  }
+
+
+  public void setRolesResolverOrdertype(Optional<String> rolesResolverOrdertype) {
+    String configured = rolesResolverOrdertype.map(String::trim).orElse(null);
+    this.rolesResolverOrdertype = (configured == null || configured.isEmpty()) ? null : configured;
+  }
+
+
+  public long getRevision() {
+    return revision;
+  }
+
+
+  public void setRevision(long revision) {
+    this.revision = revision;
+  }
+
+
+  public RuntimeContext getRuntimeContext() {
+    if (runtimeContext == null) {
+      RevisionManagement revisionManagement =
+          XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getRevisionManagement();
+      try {
+        runtimeContext = revisionManagement.getRuntimeContext(revision);
+      } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e) {
+        CentralFactoryLogging.getLogger(UserManagement.class).warn("Failed to restore RuntimeContext for revision " + revision, e);
         try {
-            return AuthValidationMode.valueOf(Optional.ofNullable(authValidationMode).orElse(AuthValidationMode.JWT.name()));
-        } catch (IllegalArgumentException e) {
-            return AuthValidationMode.JWT;
+          return revisionManagement.getRuntimeContext(-1L);
+        } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e1) {
+          throw new RuntimeException("Failed to resolve default revision.");
         }
+      }
     }
+    return runtimeContext;
+  }
 
-    public void setAuthValidationMode(AuthValidationMode mode) {
-        this.authValidationMode = (mode != null ? mode : AuthValidationMode.JWT).name();
-    }
 
-    public String getAssociatedOrdertype() {
-        return associatedOrdertype;
-    }
+  @Override
+  public RuntimeContext getRolesResolverRuntimeContext() {
+    return getRuntimeContext();
+  }
 
-    public void setAssociatedOrdertype(String associatedOrdertype) {
-        this.associatedOrdertype = associatedOrdertype;
-    }
 
-    @Override
-    public Optional<String> getRolesResolverOrdertype() {
-        String configured = rolesResolverOrdertype != null ? rolesResolverOrdertype.trim() : null;
-        if (configured == null || configured.isEmpty()) {
-            return Optional.of(DEFAULT_ROLES_RESOLVER_ORDERTYPE);
-        }
-        return Optional.of(configured);
-    }
+  @Override
+  public String getRolesResolverOrderContextKey() {
+    return "xfmg.xopctrl.jwt.token";
+  }
 
-    public void setRolesResolverOrdertype(Optional<String> rolesResolverOrdertype) {
-        String configured = rolesResolverOrdertype.map(String::trim).orElse(null);
-        this.rolesResolverOrdertype = (configured == null || configured.isEmpty()) ? null : configured;
-    }
 
-    public long getRevision() {
-        return revision;
-    }
+  public List<String> getTrustedIssuers() {
+    return trustedIssuers;
+  }
 
-    public void setRevision(long revision) {
-        this.revision = revision;
-    }
 
-    public RuntimeContext getRuntimeContext() {
-        if (runtimeContext == null) {
-            RevisionManagement revisionManagement = XynaFactory.getInstance().getFactoryManagement().getXynaFactoryControl().getRevisionManagement();
-            try {
-                runtimeContext = revisionManagement.getRuntimeContext(revision);
-            } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e) {
-                CentralFactoryLogging.getLogger(UserManagement.class).warn("Failed to restore RuntimeContext for revision " + revision, e);
-                try {
-                    return revisionManagement.getRuntimeContext(-1L);
-                } catch (XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY e1) {
-                    throw new RuntimeException("Failed to resolve default revision.");
-                }
-            }
-        }
-        return runtimeContext;
-    }
+  public void setTrustedIssuers(List<String> trustedIssuers) {
+    this.trustedIssuers = trustedIssuers;
+  }
 
-    @Override
-    public RuntimeContext getRolesResolverRuntimeContext() {
-        return getRuntimeContext();
-    }
 
-    @Override
-    public String getRolesResolverOrderContextKey() {
-        return "xfmg.xopctrl.jwt.token";
-    }
+  public List<String> getIntendedAudience() {
+    return intendedAudience;
+  }
 
-    public List<String> getTrustedIssuers() {
-        return trustedIssuers;
-    }
 
-    public void setTrustedIssuers(List<String> trustedIssuers) {
-        this.trustedIssuers = trustedIssuers;
-    }
+  public void setIntendedAudience(List<String> intendedAudience) {
+    this.intendedAudience = intendedAudience;
+  }
 
-    public List<String> getIntendedAudience() {
-        return intendedAudience;
-    }
 
-    public void setIntendedAudience(List<String> intendedAudience) {
-        this.intendedAudience = intendedAudience;
-    }
+  public Optional<String> getRoleClaimPath() {
+    return Optional.ofNullable(roleClaimPath);
+  }
 
-    public Optional<String> getRoleClaimPath() {
-        return Optional.ofNullable(roleClaimPath);
-    }
 
-    public void setRoleClaimPath(Optional<String> roleClaimPath) {
-        this.roleClaimPath = roleClaimPath.orElse(null);
-    }
+  public void setRoleClaimPath(Optional<String> roleClaimPath) {
+    this.roleClaimPath = roleClaimPath.orElse(null);
+  }
 
-    public Optional<String> getDefaultRole() {
-        return Optional.ofNullable(defaultRole);
-    }
 
-    public void setDefaultRole(Optional<String> defaultRole) {
-        this.defaultRole = defaultRole.orElse(null);
-    }
+  public Optional<String> getDefaultRole() {
+    return Optional.ofNullable(defaultRole);
+  }
 
-    public Optional<String> getRolePrefix() {
-        return Optional.ofNullable(rolePrefix);
-    }
 
-    public void setRolePrefix(Optional<String> rolePrefix) {
-        this.rolePrefix = rolePrefix.orElse(null);
-    }
+  public void setDefaultRole(Optional<String> defaultRole) {
+    this.defaultRole = defaultRole.orElse(null);
+  }
 
-    public Optional<String> getRoleSuffix() {
-        return Optional.ofNullable(roleSuffix);
-    }
 
-    public void setRoleSuffix(Optional<String> roleSuffix) {
-        this.roleSuffix = roleSuffix.orElse(null);
-    }
+  public Optional<String> getRolePrefix() {
+    return Optional.ofNullable(rolePrefix);
+  }
 
-    public List<String> getRoleOrder() {
-        return roleOrder;
-    }
 
-    public void setRoleOrder(List<String> roleOrder) {
-        this.roleOrder = roleOrder;
-    }
+  public void setRolePrefix(Optional<String> rolePrefix) {
+    this.rolePrefix = rolePrefix.orElse(null);
+  }
 
-    public Optional<String> getJwksUri() { return Optional.ofNullable(jwksUri); }
 
-    public void setJwksUri(Optional<String> jwksUri) { this.jwksUri = jwksUri.orElse(null); }
+  public Optional<String> getRoleSuffix() {
+    return Optional.ofNullable(roleSuffix);
+  }
 
-    @Override
-    public void appendInformation(StringBuilder output) {
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-              .append("Trusted Issuers: ").append(trustedIssuers).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-              .append("Intended Audience: ").append(intendedAudience).append("\n");
-        AuthValidationMode mode = getAuthValidationMode();
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-              .append("Auth Validation Mode: ").append(mode)
-              .append(mode == AuthValidationMode.JWT ? " (default)" : "").append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-              .append("Role Claim Path: ").append(getRoleClaimPath().orElse("Not Configured")).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Default Role: ").append(getDefaultRole().orElse("Not Configured")).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Role Prefix: ").append(getRolePrefix().orElse("Not Configured")).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Role Suffix: ").append(getRoleSuffix().orElse("Not Configured")).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Role Order: ").append(roleOrder != null && !roleOrder.isEmpty() ? roleOrder : "Not Configured").append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("JWKS URI: ").append(getJwksUri().orElse("Not Configured (auto-discover)")).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Associated Order Type: ").append(associatedOrdertype).append(" @rev_").append(revision).append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Roles Resolver Order Type: ")
-            .append(rolesResolverOrdertype != null ? rolesResolverOrdertype : DEFAULT_ROLES_RESOLVER_ORDERTYPE)
-            .append(rolesResolverOrdertype != null ? "" : " (default)").append("\n");
-        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
-            .append("Roles Resolver Runtime Context: @rev_").append(revision).append(" (same as associated)").append("\n");
-    }
 
+  public void setRoleSuffix(Optional<String> roleSuffix) {
+    this.roleSuffix = roleSuffix.orElse(null);
+  }
+
+
+  public List<String> getRoleOrder() {
+    return roleOrder;
+  }
+
+
+  public void setRoleOrder(List<String> roleOrder) {
+    this.roleOrder = roleOrder;
+  }
+
+
+  public Optional<String> getJwksUri() {
+    return Optional.ofNullable(jwksUri);
+  }
+
+
+  public void setJwksUri(Optional<String> jwksUri) {
+    this.jwksUri = jwksUri.orElse(null);
+  }
+
+
+  public Optional<String> getPreferredDomain() {
+    return Optional.ofNullable(preferredDomain);
+  }
+
+
+  public void setPreferredDomain(Optional<String> preferredDomain) {
+    this.preferredDomain = preferredDomain.orElse(null);
+  }
+
+
+  @Override
+  public void appendInformation(StringBuilder output) {
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Trusted Issuers: ").append(trustedIssuers).append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Intended Audience: ").append(intendedAudience).append("\n");
+    AuthValidationMode mode = getAuthValidationMode();
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Auth Validation Mode: ").append(mode)
+        .append(mode == AuthValidationMode.JWT ? " (default)" : "").append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Role Claim Path: ")
+        .append(getRoleClaimPath().orElse("Not Configured")).append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Default Role: ").append(getDefaultRole().orElse("Not Configured"))
+        .append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Role Prefix: ").append(getRolePrefix().orElse("Not Configured"))
+        .append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Role Suffix: ").append(getRoleSuffix().orElse("Not Configured"))
+        .append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Role Order: ")
+        .append(roleOrder != null && !roleOrder.isEmpty() ? roleOrder : "Not Configured").append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("JWKS URI: ")
+        .append(getJwksUri().orElse("Not Configured (auto-discover)")).append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Associated Order Type (for authentication): ")
+        .append(getAssociatedOrdertype()).append(associatedOrdertype != null && !associatedOrdertype.trim().isEmpty() ? "" : " (default)")
+        .append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Roles Resolver Order Type: ")
+        .append(getRolesResolverOrdertype().orElse(DEFAULT_ROLES_RESOLVER_ORDERTYPE))
+        .append(rolesResolverOrdertype != null && !rolesResolverOrdertype.trim().isEmpty() ? "" : " (default)").append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Runtime Context (for both order types): @rev_").append(revision)
+        .append("\n");
+    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Preferred Domain: ")
+        .append(getPreferredDomain().orElse("Not Configured")).append("\n");
+  }
+
+
+  @Override
+  public List<String> resolveAvailableRoles(String domainName, String credential) {
+    JWTRolesResolver resolver = new JWTRolesResolver(
+        getRolesResolverOrdertype().orElse(null),
+        getRolesResolverRuntimeContext(),
+        getRolesResolverOrderContextKey()
+    );
+    return resolver.resolveAvailableRoles(domainName, credential);
+  }
 }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
@@ -25,12 +25,14 @@ import com.gip.xyna.XynaFactory;
 import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RevisionManagement;
 import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
 import com.gip.xyna.xfmg.xopctrl.DomainTypeSpecificData;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.RolesResolver;
 import com.gip.xyna.xfmg.xopctrl.usermanagement.UserManagement;
 import com.gip.xyna.xnwh.exceptions.XNWH_OBJECT_NOT_FOUND_FOR_PRIMARY_KEY;
 
-public class JWTDomainSpecificData implements DomainTypeSpecificData {
+public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResolver {
 
-    private static final long serialVersionUID = 7177523157271609582L;
+    private static final long serialVersionUID = 1L;
+    private static final String DEFAULT_ROLES_RESOLVER_ORDERTYPE = "xact.http.jwt.auth.ResolveAvailableRolesWithJWT";
 
     public enum AuthValidationMode {
         HEADER,
@@ -47,6 +49,7 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData {
     private String jwksUri;
     private String authValidationMode = AuthValidationMode.JWT.name();
     private String associatedOrdertype;
+    private String rolesResolverOrdertype;
     private long revision;
     private transient RuntimeContext runtimeContext;
 
@@ -56,7 +59,7 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData {
                                  Optional<String> roleClaimPath, Optional<String> defaultRole,
                                  Optional<String> rolePrefix, Optional<String> roleSuffix,
                                  List<String> roleOrder, Optional<String> jwksUri,
-                                 String associatedOrdertype, long revision) {
+                                 String associatedOrdertype, Optional<String> rolesResolverOrdertype, long revision) {
         this.trustedIssuers = trustedIssuers;
         this.intendedAudience = intendedAudience;
         this.roleClaimPath = roleClaimPath.orElse(null);
@@ -66,6 +69,7 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData {
         this.roleOrder = roleOrder;
         this.jwksUri = jwksUri.orElse(null);
         this.associatedOrdertype = associatedOrdertype;
+        this.rolesResolverOrdertype = rolesResolverOrdertype.orElse(null);
         this.revision = revision;
     }
 
@@ -87,6 +91,20 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData {
 
     public void setAssociatedOrdertype(String associatedOrdertype) {
         this.associatedOrdertype = associatedOrdertype;
+    }
+
+    @Override
+    public Optional<String> getRolesResolverOrdertype() {
+        String configured = rolesResolverOrdertype != null ? rolesResolverOrdertype.trim() : null;
+        if (configured == null || configured.isEmpty()) {
+            return Optional.of(DEFAULT_ROLES_RESOLVER_ORDERTYPE);
+        }
+        return Optional.of(configured);
+    }
+
+    public void setRolesResolverOrdertype(Optional<String> rolesResolverOrdertype) {
+        String configured = rolesResolverOrdertype.map(String::trim).orElse(null);
+        this.rolesResolverOrdertype = (configured == null || configured.isEmpty()) ? null : configured;
     }
 
     public long getRevision() {
@@ -112,6 +130,16 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData {
             }
         }
         return runtimeContext;
+    }
+
+    @Override
+    public RuntimeContext getRolesResolverRuntimeContext() {
+        return getRuntimeContext();
+    }
+
+    @Override
+    public String getRolesResolverOrderContextKey() {
+        return "xfmg.xopctrl.jwt.token";
     }
 
     public List<String> getTrustedIssuers() {
@@ -198,6 +226,12 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData {
             .append("JWKS URI: ").append(getJwksUri().orElse("Not Configured (auto-discover)")).append("\n");
         output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
             .append("Associated Order Type: ").append(associatedOrdertype).append(" @rev_").append(revision).append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Roles Resolver Order Type: ")
+            .append(rolesResolverOrdertype != null ? rolesResolverOrdertype : DEFAULT_ROLES_RESOLVER_ORDERTYPE)
+            .append(rolesResolverOrdertype != null ? "" : " (default)").append("\n");
+        output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA)
+            .append("Roles Resolver Runtime Context: @rev_").append(revision).append(" (same as associated)").append("\n");
     }
 
 }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
@@ -115,7 +115,6 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
   }
 
 
-  @Override
   public Optional<String> getRolesResolverOrdertype() {
     String configured = rolesResolverOrdertype != null ? rolesResolverOrdertype.trim() : null;
     if (configured == null || configured.isEmpty()) {
@@ -160,13 +159,11 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
   }
 
 
-  @Override
   public RuntimeContext getRolesResolverRuntimeContext() {
     return getRuntimeContext();
   }
 
 
-  @Override
   public String getRolesResolverOrderContextKey() {
     return "xfmg.xopctrl.jwt.token";
   }

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTDomainSpecificData.java
@@ -61,7 +61,6 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
   private String associatedOrdertype;
   private String rolesResolverOrdertype;
   private long revision;
-  private String preferredDomain;
   private transient RuntimeContext runtimeContext;
 
 
@@ -72,7 +71,7 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
   public JWTDomainSpecificData(List<String> trustedIssuers, List<String> intendedAudience, Optional<String> roleClaimPath,
                                Optional<String> defaultRole, Optional<String> rolePrefix, Optional<String> roleSuffix,
                                List<String> roleOrder, Optional<String> jwksUri, String associatedOrdertype,
-                               Optional<String> rolesResolverOrdertype, long revision, Optional<String> preferredDomain) {
+                               Optional<String> rolesResolverOrdertype, long revision) {
     this.trustedIssuers = trustedIssuers;
     this.intendedAudience = intendedAudience;
     this.roleClaimPath = roleClaimPath.orElse(null);
@@ -84,7 +83,6 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
     this.associatedOrdertype = associatedOrdertype;
     this.rolesResolverOrdertype = rolesResolverOrdertype.orElse(null);
     this.revision = revision;
-    this.preferredDomain = preferredDomain.orElse(null);
   }
 
 
@@ -254,16 +252,6 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
   }
 
 
-  public Optional<String> getPreferredDomain() {
-    return Optional.ofNullable(preferredDomain);
-  }
-
-
-  public void setPreferredDomain(Optional<String> preferredDomain) {
-    this.preferredDomain = preferredDomain.orElse(null);
-  }
-
-
   @Override
   public void appendInformation(StringBuilder output) {
     output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Trusted Issuers: ").append(trustedIssuers).append("\n");
@@ -291,8 +279,6 @@ public class JWTDomainSpecificData implements DomainTypeSpecificData, RolesResol
         .append(rolesResolverOrdertype != null && !rolesResolverOrdertype.trim().isEmpty() ? "" : " (default)").append("\n");
     output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Runtime Context (for both order types): @rev_").append(revision)
         .append("\n");
-    output.append(UserManagement.INDENT_FOR_DOMAIN_SPECIFIC_DATA).append("Preferred Domain: ")
-        .append(getPreferredDomain().orElse("Not Configured")).append("\n");
   }
 
 

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTRolesResolver.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTRolesResolver.java
@@ -1,0 +1,132 @@
+/*
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ * Copyright 2026 Xyna GmbH, Germany
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ */
+package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import com.gip.xyna.XynaFactory;
+import com.gip.xyna.xdev.xfractmod.xmdm.Container;
+import com.gip.xyna.xdev.xfractmod.xmdm.GeneralXynaObject;
+import com.gip.xyna.xdev.xfractmod.xmdm.XynaObjectList;
+import com.gip.xyna.xfmg.xfctrl.revisionmgmt.RuntimeContext;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.DomainName;
+import com.gip.xyna.xfmg.xopctrl.usermanagement.RolesResolver;
+import com.gip.xyna.xprc.XynaOrderServerExtension;
+import com.gip.xyna.xprc.XynaOrderCreationParameter;
+import com.gip.xyna.xprc.xfractwfe.InvalidObjectPathException;
+import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
+
+
+/**
+ * RolesResolver implementation for JWT domains.
+ * Resolves available login roles by executing a configured workflow with the JWT token.
+ */
+public class JWTRolesResolver implements RolesResolver {
+
+  private final String rolesResolverOrdertype;
+  private final RuntimeContext runtimeContext;
+  private final String orderContextKey;
+
+  public JWTRolesResolver(String rolesResolverOrdertype, RuntimeContext runtimeContext, String orderContextKey) {
+    this.rolesResolverOrdertype = rolesResolverOrdertype;
+    this.runtimeContext = runtimeContext;
+    this.orderContextKey = orderContextKey;
+  }
+
+  @Override
+  public Optional<String> getRolesResolverOrdertype() {
+    return Optional.ofNullable(rolesResolverOrdertype);
+  }
+
+  @Override
+  public RuntimeContext getRolesResolverRuntimeContext() {
+    return runtimeContext;
+  }
+
+  @Override
+  public String getRolesResolverOrderContextKey() {
+    return orderContextKey;
+  }
+
+  @Override
+  public List<String> resolveAvailableRoles(String domainName, String credential) {
+    List<String> roleNames = new ArrayList<>();
+
+    if (rolesResolverOrdertype == null || rolesResolverOrdertype.isEmpty() || runtimeContext == null || orderContextKey == null || orderContextKey.isEmpty() || credential == null || credential.isEmpty()) {
+      return roleNames;
+    }
+
+    try {
+      DomainName domainNameObj = new DomainName(domainName);
+      DestinationKey destKey = new DestinationKey(rolesResolverOrdertype, runtimeContext);
+      XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(destKey, domainNameObj);
+      XynaOrderServerExtension xose = new XynaOrderServerExtension(xocp);
+      xose.setNewOrderContext();
+      xose.getOrderContext().set(orderContextKey, credential);
+
+      XynaOrderServerExtension resultOrder =
+          XynaFactory.getInstance().getProcessing().getXynaProcessCtrlExecution().startOrderSynchronous(xose);
+
+      addRoleNames(roleNames, resultOrder.getOutputPayload());
+    } catch (Exception e) {
+      // Intentionally ignored: unresolved roles result in an empty list.
+    }
+
+    return roleNames;
+  }
+
+  private void addRoleNames(List<String> roleNames, GeneralXynaObject output) {
+    if (output == null) {
+      return;
+    }
+    if (output instanceof XynaObjectList<?>) {
+      for (Object item : (XynaObjectList<?>) output) {
+        addRoleName(roleNames, item);
+      }
+      return;
+    }
+    if (output instanceof Container) {
+      Container container = (Container) output;
+      for (int i = 0; i < container.size(); i++) {
+        addRoleName(roleNames, container.get(i));
+      }
+      return;
+    }
+    addRoleName(roleNames, output);
+  }
+
+  private void addRoleName(List<String> roleNames, Object item) {
+    if (!(item instanceof GeneralXynaObject)) {
+      return;
+    }
+    try {
+      Object nameField = ((GeneralXynaObject) item).get("name");
+      if (nameField instanceof String) {
+        String roleName = ((String) nameField).trim();
+        if (!roleName.isEmpty()) {
+          roleNames.add(roleName);
+        }
+      }
+    } catch (InvalidObjectPathException e) {
+      // Ignore items without a 'name' field.
+    }
+  }
+
+}

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTRolesResolver.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTRolesResolver.java
@@ -51,21 +51,6 @@ public class JWTRolesResolver implements RolesResolver {
   }
 
   @Override
-  public Optional<String> getRolesResolverOrdertype() {
-    return Optional.ofNullable(rolesResolverOrdertype);
-  }
-
-  @Override
-  public RuntimeContext getRolesResolverRuntimeContext() {
-    return runtimeContext;
-  }
-
-  @Override
-  public String getRolesResolverOrderContextKey() {
-    return orderContextKey;
-  }
-
-  @Override
   public List<String> resolveAvailableRoles(String domainName, String credential) {
     List<String> roleNames = new ArrayList<>();
 

--- a/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTUserAuthentication.java
+++ b/server/src/com/gip/xyna/xfmg/xopctrl/usermanagement/jwt/JWTUserAuthentication.java
@@ -17,6 +17,8 @@
  */
 package com.gip.xyna.xfmg.xopctrl.usermanagement.jwt;
 
+
+
 import org.apache.log4j.Logger;
 
 import com.gip.xyna.CentralFactoryLogging;
@@ -33,78 +35,98 @@ import com.gip.xyna.xprc.XynaOrderCreationParameter;
 import com.gip.xyna.xprc.XynaOrderServerExtension;
 import com.gip.xyna.xprc.xpce.dispatcher.DestinationKey;
 
+
+
 public class JWTUserAuthentication extends OrderBackedUserAuthentication {
 
-    public static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
-    private static final Logger logger = CentralFactoryLogging.getLogger(JWTUserAuthentication.class);
+  public static final String ORDER_CONTEXT_KEY_JWT_TOKEN = "xfmg.xopctrl.jwt.token";
+  public static final String ORDER_CONTEXT_KEY_SELECTED_ROLE = "xfmg.xopctrl.jwt.selectedRole";
 
-    private final JWTDomainSpecificData domainSpecificData;
-    private final String domainName;
+  /** Separator used to encode an optional selectedRole prefix into the password field.
+   *  \0 is safe because JWT tokens are base64url-encoded and never contain this character. */
+  private static final char SELECTED_ROLE_SEPARATOR = '\0';
 
-    public JWTUserAuthentication(Domain domain) {
-        super(domain);
-        this.domainSpecificData = (JWTDomainSpecificData) domain.getDomainSpecificData();
-        this.domainName = domain.getName();
+  private static final Logger logger = CentralFactoryLogging.getLogger(JWTUserAuthentication.class);
+
+  private final JWTDomainSpecificData domainSpecificData;
+  private final String domainName;
+
+
+  public JWTUserAuthentication(Domain domain) {
+    super(domain);
+    this.domainSpecificData = (JWTDomainSpecificData) domain.getDomainSpecificData();
+    this.domainName = domain.getName();
+  }
+
+
+  public JWTUserAuthentication(JWTDomainSpecificData domainSpecificData) {
+    super(null);
+    this.domainSpecificData = domainSpecificData;
+    this.domainName = null;
+  }
+
+
+  @Override
+  public XynaOrder generateAuthOrder(String username, String password, Domain domain, int retry) {
+    // password may be encoded as "selectedRole\0jwtToken" – split if separator present
+    String selectedRole = null;
+    String jwtToken = password;
+    if (password != null) {
+      int sepIdx = password.indexOf(SELECTED_ROLE_SEPARATOR);
+      if (sepIdx >= 0) {
+        selectedRole = password.substring(0, sepIdx);
+        jwtToken = password.substring(sepIdx + 1);
+      }
     }
 
-    public JWTUserAuthentication(JWTDomainSpecificData domainSpecificData) {
-        super(null);
-        this.domainSpecificData = domainSpecificData;
-        this.domainName = null;
+    DomainName domainName = new DomainName(domain.getName());
+    DestinationKey dk = new DestinationKey(domainSpecificData.getAssociatedOrdertype(), domainSpecificData.getRuntimeContext());
+    XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(dk, domainName);
+    XynaOrderServerExtension xo = new XynaOrderServerExtension(xocp);
+    xo.setNewOrderContext();
+    xo.getOrderContext().set(ORDER_CONTEXT_KEY_JWT_TOKEN, jwtToken);
+    if (selectedRole != null && !selectedRole.isEmpty()) {
+      xo.getOrderContext().set(ORDER_CONTEXT_KEY_SELECTED_ROLE, selectedRole);
     }
+    return xo;
+  }
 
 
-    @Override
-    public XynaOrder generateAuthOrder(String username, String password, Domain domain, int retry) {
-        DomainName domainName = new DomainName(domain.getName());
-        DestinationKey dk = new DestinationKey(domainSpecificData.getAssociatedOrdertype(), domainSpecificData.getRuntimeContext());
-        XynaOrderCreationParameter xocp = new XynaOrderCreationParameter(dk, domainName);
-        XynaOrderServerExtension xo = new XynaOrderServerExtension(xocp);
-        xo.setNewOrderContext();
-        xo.getOrderContext().set(ORDER_CONTEXT_KEY_JWT_TOKEN, password);
-        return xo;
+  @Override
+  public Role handleResponse(AuthenticationResult result) throws XFMG_UserAuthenticationFailedException {
+    if (result != null && result.wasSuccesfull()) {
+      if (logger.isDebugEnabled()) {
+        logger.debug("JWT authentication succeeded for user '" + username + "' in domain '" + domainName + "'.");
+      }
+      try {
+        return XynaFactory.getPortalInstance().getXynaMultiChannelPortalPortal()
+            .getRole(result.getRole(), UserManagement.PREDEFINED_LOCALDOMAIN_NAME);
+      } catch (Exception e) {
+        logger.warn("JWT authentication returned role '" + result.getRole() + "' which could not be resolved.", e);
+        throw new XFMG_UserAuthenticationFailedException(username, e);
+      }
     }
-
-
-    @Override
-    public Role handleResponse(AuthenticationResult result) throws XFMG_UserAuthenticationFailedException {
-        if (result != null && result.wasSuccesfull()) {
-            if (logger.isDebugEnabled()) {
-                logger.debug("JWT authentication succeeded for user '" + username + "' in domain '" + domainName + "'.");
-            }
-            try {
-                return XynaFactory.getPortalInstance().getXynaMultiChannelPortalPortal()
-                    .getRole(result.getRole(), UserManagement.PREDEFINED_LOCALDOMAIN_NAME);
-            } catch (Exception e) {
-                logger.warn("JWT authentication returned role '" + result.getRole() + "' which could not be resolved.", e);
-                throw new XFMG_UserAuthenticationFailedException(username, e);
-            }
-        }
-        if (logger.isDebugEnabled()) {
-            logger.debug("JWT authentication failed for user '" + username + "' in domain '" + domainName + "'.");
-        }
-        return null;
+    if (logger.isDebugEnabled()) {
+      logger.debug("JWT authentication failed for user '" + username + "' in domain '" + domainName + "'.");
     }
+    return null;
+  }
 
 
-    @Override
-    public Role handleError(Throwable exception) throws XFMG_UserAuthenticationFailedException {
-        logger.warn("JWT authentication order execution failed for user '" + username + "'.", exception);
-        return null;
+  @Override
+  public Role handleError(Throwable exception) throws XFMG_UserAuthenticationFailedException {
+    logger.warn("JWT authentication order execution failed for user '" + username + "'.", exception);
+    return null;
+  }
+
+
+  public String getConfiguredDefaultRole() {
+    String defaultRole = domainSpecificData.getDefaultRole().orElse(null);
+    if (defaultRole == null) {
+      return null;
     }
-
-
-    public String getConfiguredDefaultRole() {
-        String defaultRole = domainSpecificData.getDefaultRole().orElse(null);
-        if (defaultRole == null) {
-            return null;
-        }
-        String trimmed = defaultRole.trim();
-        return trimmed.isEmpty() ? null : trimmed;
-    }
-
-
-
-
+    String trimmed = defaultRole.trim();
+    return trimmed.isEmpty() ? null : trimmed;
+  }
 
 }


### PR DESCRIPTION
### **Add feature to select JWT role via dropdown in login form** (zeta update needed)

### **Summary**
This PR implements end-to-end JWT role selection in the login flow. 
Users can now view available roles for their JWT domain via a dropdown in the GUI and select a specific role during login.
If no role is selected, the authentication logic falls back to the original behavior (highest-priority role or default role).

### **Key Features**

**1. Role Discovery & Presentation**
- Extended /auth/externalUserLoginInformation returns available roles per domain
- Domain order can be controlled via H5XdevFilter preferredDomain parameter
- Roles are resolved via configurable rolesResolverOrdertype (default: ResolveAvailableRolesWithJWT)
- Frontend renders a role dropdown only if roles are available

**2. Role Selection During Login**
- Extended /auth/externalUserLogin endpoint accepts optional selectedRole in request body
- Selected role is securely encoded with the JWT token (selectedRole\0jwtToken)
- Server-side verification ensures selected role is actually present in JWT claims
- Prevents role spoofing: invalid role selections cause immediate authentication failure

**3. Role Selection Strategy**
- With explicit selectedRole: Role is verified against JWT claims and used if valid
- Without selectedRole: Falls back to highest-priority role from roleOrder, then defaultRole (fully backward compatible)
- Invalid selection: Role not present in JWT claims triggers authentication failure
