### PR TITLE
Special netconf 1.1 parsing

### DIFF
--- a/modules/base/base/XMOM/xact/templates/NETCONF.xml
+++ b/modules/base/base/XMOM/xact/templates/NETCONF.xml
@@ -1,21 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!--
- * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- * Copyright 2022 Xyna GmbH, Germany
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *  http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
--->
 <DataType xmlns="http://www.gip.com/xyna/xdev/xfractmod" BaseTypeName="XML" BaseTypePath="xact.templates" IsAbstract="false" Label="NETCONF" TypeName="NETCONF" TypePath="xact.templates" Version="1.8">
   <Meta>
     <IsServiceGroupOnly>false</IsServiceGroupOnly>
@@ -60,19 +43,61 @@
         <CodeSnippet Type="Java">if ("1.1".equals(version)) {
         String MSG_END = "\n##\n";
         if (!response.endsWith(MSG_END)) {
+            logger.warn("NETCONF 1.1 response is still missing its ending message '##'...");
             return false;
         }
+        // currently there are two patterns:
+	 // - with \n before #
+        // - without \n before #
+        // seems that in rare cases the router counts the \n to its chunk, but does not print it for chunk separation afterwards (router bug?)
+        // -&gt; therefore: invent a fallback pattern without the newline and take it into account during response index counting
         java.util.regex.Pattern CHUNK_SIZE_PATTERN = java.util.regex.Pattern.compile("^\\n#(\\d+)\\n.*");
+        java.util.regex.Pattern CHUNK_SIZE_PATTERN_WO_LF = java.util.regex.Pattern.compile("^#(\\d+)\\n.*");
         java.util.regex.Matcher matcher;
+        java.util.regex.Matcher matcher_wo_lf;
+        boolean fallback = false;
         int responseIndex = 0;
         do {
             matcher = CHUNK_SIZE_PATTERN.matcher(response.substring(responseIndex));
+            matcher_wo_lf = CHUNK_SIZE_PATTERN_WO_LF.matcher(response.substring(responseIndex));
             if (!matcher.find()) {
-                break;
+                // nominal pattern did not match, maybe it can be saved with the fallback pattern
+                if(matcher_wo_lf.find()){
+                    if(logger.isDebugEnabled()){
+                        logger.debug("Saved matching without LF at line beginning (fallback pattern)...");
+                    }
+                    fallback = true;
+                }
+                else {
+                    if(logger.isDebugEnabled()){
+                        logger.debug("do-while broken");
+                    }
+                    break;
+                }
             }
-            String group = matcher.group(1);
+            String group;
+            if(fallback){
+                group = matcher_wo_lf.group(1);
+            }
+            else {
+                group = matcher.group(1);
+            }
             int chunkSize = Integer.valueOf(group);
-            responseIndex += 3 + group.length() + chunkSize; // 3 -&gt; \n# before chunk-size and \n after chunk-size
+            if(fallback){
+                responseIndex += 2 + group.length() + chunkSize; // 2 -&gt; # + chunk-size and \n after chunk-size - reduced fallback pattern
+            }
+            else {
+                responseIndex += 3 + group.length() + chunkSize; // 3 -&gt; \n# before chunk-size and \n after chunk-size
+            }
+
+            if(logger.isDebugEnabled()){
+                logger.debug("...responseIndex: " + responseIndex);
+                logger.debug("...chunkSize: " + chunkSize);
+                logger.debug("...true response length: " + response.length());
+                logger.debug("...MSG_END length: " + MSG_END.length());
+            }
+            // reset fallback marker
+            fallback = false;
         } while (responseIndex &lt;= response.length() - MSG_END.length());
         return responseIndex == response.length() - MSG_END.length();
     } else {
@@ -115,21 +140,50 @@
         <CodeSnippet Type="Java">if ("1.1".equals(version)) {
         String MSG_END = "\n##\n";
         StringBuilder contentBuilder = new StringBuilder();
+        // currently there are two patterns:
+	 // - with \n before #
+        // - without \n before #
+        // seems that in rare cases the router counts the \n to its chunk, but does not print it for chunk separation afterwards (router bug?)
+        // -&gt; therefore: invent a fallback pattern without the newline and take it into account during response index counting
         java.util.regex.Pattern CHUNK_SIZE_PATTERN = java.util.regex.Pattern.compile("^\\n#(\\d+)\\n");
+        java.util.regex.Pattern CHUNK_SIZE_PATTERN_WO_LF = java.util.regex.Pattern.compile("^#(\\d+)\\n");
         java.util.regex.Matcher matcher;
+        java.util.regex.Matcher matcher_wo_lf;
+        boolean fallback = false;
         int responseIndex = 0;
 
         while (responseIndex &lt; response.getResponse().getContent().length() - MSG_END.length()) {
             matcher = CHUNK_SIZE_PATTERN.matcher(response.getResponse().getContent().substring(responseIndex));
+            matcher_wo_lf = CHUNK_SIZE_PATTERN_WO_LF.matcher(response.getResponse().getContent().substring(responseIndex));
             if (!matcher.find()) {
-              throw new RuntimeException("invalid response @" + responseIndex + " , response: " + response.getResponse().getContent());
+                // nominal pattern did not match, maybe it can be saved with the fallback pattern
+                if(matcher_wo_lf.find()){
+                    if(logger.isDebugEnabled()){
+                        logger.debug("Saved matching without LF at line beginning (fallback pattern)...");
+                    }
+                    fallback = true;
+                }
+                else{
+                    throw new RuntimeException("invalid response @" + responseIndex + " , response: " + response.getResponse().getContent());
+                }
             }
-            String group = matcher.group(1);
+            String group;
+            int paragraph_correction = 3;
+            if(fallback){
+                group = matcher_wo_lf.group(1);
+                paragraph_correction = 2;
+            }
+            else{
+                group = matcher.group(1);
+            }
             int chunkSize = Integer.valueOf(group);
-            int fromIndex = responseIndex + 3 + group.length();
+            int fromIndex = responseIndex + paragraph_correction + group.length();
             int toIndex = fromIndex + chunkSize;
             contentBuilder.append(response.getResponse().getContent().substring(fromIndex, toIndex));
             responseIndex = toIndex;
+
+            // reset fallback marker
+            fallback = false;
         }
         response.getResponse().setContent(contentBuilder.toString());
     } else {

--- a/modules/base/base/application.xml
+++ b/modules/base/base/application.xml
@@ -16,7 +16,7 @@
  * limitations under the License.
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 -->
-<Application applicationName="Base" comment="" factoryVersion="" versionName="1.1.4" xmlVersion="1.1">
+<Application applicationName="Base" comment="" factoryVersion="" versionName="1.1.5" xmlVersion="1.1">
   <ApplicationInfo>
     <Description Lang="DE">Diverse grundlegende DatenTypen und Services</Description>
     <Description Lang="EN">Miscellaneous essential data types and services</Description>

--- a/modules/base/list/application.xml
+++ b/modules/base/list/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/base/net/application.xml
+++ b/modules/base/net/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/base/storables/application.xml
+++ b/modules/base/storables/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/connection/connection/application.xml
+++ b/modules/xact/connection/connection/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/dhcp/client/application.xml
+++ b/modules/xact/dhcp/client/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/ldap/application.xml
+++ b/modules/xact/ldap/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/mail/application.xml
+++ b/modules/xact/mail/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/queue/queue/application.xml
+++ b/modules/xact/queue/queue/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/radius/server/application.xml
+++ b/modules/xact/radius/server/application.xml
@@ -20,7 +20,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>Crypto</ApplicationName>

--- a/modules/xact/script/application.xml
+++ b/modules/xact/script/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/snmp/application.xml
+++ b/modules/xact/snmp/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/soap/application.xml
+++ b/modules/xact/soap/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xact/ssh/sftp/application.xml
+++ b/modules/xact/ssh/sftp/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
       <RuntimeContextRequirement>
         <ApplicationName>SSHServer</ApplicationName>

--- a/modules/xact/velocity/application.xml
+++ b/modules/xact/velocity/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xfmg/csv/application.xml
+++ b/modules/xfmg/csv/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xfmg/json/application.xml
+++ b/modules/xfmg/json/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xfmg/node/application.xml
+++ b/modules/xfmg/node/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xfmg/user/application.xml
+++ b/modules/xfmg/user/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>>
   </ApplicationInfo>

--- a/modules/xfmg/xynaproperty/application.xml
+++ b/modules/xfmg/xynaproperty/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xfmg/yang/application.xml
+++ b/modules/xfmg/yang/application.xml
@@ -22,7 +22,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xint/crypto/application.xml
+++ b/modules/xint/crypto/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xint/regexp/application.xml
+++ b/modules/xint/regexp/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xnwh/timeseries/application.xml
+++ b/modules/xnwh/timeseries/application.xml
@@ -23,7 +23,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>

--- a/modules/xprc/processing/application.xml
+++ b/modules/xprc/processing/application.xml
@@ -24,7 +24,7 @@
     <RuntimeContextRequirements>
       <RuntimeContextRequirement>
         <ApplicationName>Base</ApplicationName>
-        <VersionName>1.1.4</VersionName>
+        <VersionName>1.1.5</VersionName>
       </RuntimeContextRequirement>
     </RuntimeContextRequirements>
   </ApplicationInfo>


### PR DESCRIPTION
When communicating with NETCONF 1.1 in some cases devices do not print their answers in the following pattern:
```
\n
#<length>\n
<response chunk>
```

Instead the first newline will be counted to the chunk and the transition between chunks looks like this:
```
\n
#<length1>\n
<response1>
#<length2>\n
<response2>
```
This halts the parsing, as the expected pattern is currently `\n#<length>\n`.

The PR mitigates this and differentiates between cases with and without leading newlines.
Furthermore some debug output lines are added for a better debug experience during runtime.

Would be happy to get this reviewed and I am open to improvements of the two case implementation.